### PR TITLE
✨Color, Font 추가

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -90,4 +90,4 @@ identifier_name:
     excluded:
         - id                # id라는 변수명에 대해서는 identifier_name rule을 적용하지 않습니다.
     allowed_symbols:
-        - _
+        - _                 # underscore에 대해서는 예외처리합니다.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -47,7 +47,6 @@ opt_in_rules:
     - identical_operands                            # 같은 것을 비교할 필요 없습니다.
     - implicit_return                               # closure, functions, getter에서 암묵적 return을 지향합니다.
     - implicitly_unwrapped_optional                 # 암시적 언래핑을 지양합니다. (IBOutlet은 예외)
-    - indentation_width                             # 첫째줄에서는 indent를 금지하고, indent는 4칸으로 설정합니다.
     - last_where                                    # Collection에서 .filter { }.last 말고 .last(where: )를 사용합니다.
     - let_var_whitespace                            # let, var 프로퍼티들은 다른 statement들과 한 줄을 띄워서 작성합니다.
     - literal_expression_end_indentation            # 배열, Dictionary의 마지막 indentation은 처음과 같아야합니다.
@@ -90,3 +89,5 @@ nesting:                    # nesting을 설정합니다.
 identifier_name:
     excluded:
         - id                # id라는 변수명에 대해서는 identifier_name rule을 적용하지 않습니다.
+    allowed_symbols:
+        - _

--- a/Resources/Colors.xcassets/Contents.json
+++ b/Resources/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Colors.xcassets/grayC5C5C5.colorset/Contents.json
+++ b/Resources/Colors.xcassets/grayC5C5C5.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.773",
+          "green" : "0.773",
+          "red" : "0.773"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Colors.xcassets/mainYellow.colorset/Contents.json
+++ b/Resources/Colors.xcassets/mainYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6A",
+          "green" : "0xF5",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/DesignSystem/Color/Palette.swift
+++ b/Sources/DesignSystem/Color/Palette.swift
@@ -1,0 +1,22 @@
+//
+//  Palette.swift
+//  MatStar
+//
+//  Created by 김승창 on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+enum Palette: String {
+    case mainYellow
+    case grayC5C5C5
+
+    var hexString: String {
+        switch self {
+        case .mainYellow:
+            return "#FFF56AFF"
+            
+        case .grayC5C5C5:
+            return "#C5C5C5FF"
+        }
+    }
+}

--- a/Sources/DesignSystem/DesignSystemDummy.swift
+++ b/Sources/DesignSystem/DesignSystemDummy.swift
@@ -1,9 +1,0 @@
-//
-//  DesignSystemDummy.swift
-//  MatStar
-//
-//  Created by 김승창 on 2022/10/11.
-//  Copyright © 2022 Try-ing. All rights reserved.
-//
-
-import Foundation

--- a/Sources/DesignSystem/Font/Font.swift
+++ b/Sources/DesignSystem/Font/Font.swift
@@ -1,0 +1,89 @@
+//
+//  Font.swift
+//  MatStar
+//
+//  Created by 김승창 on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+
+enum Font {
+    enum Name: String {
+        case system
+    }
+    
+    enum Size: CGFloat {
+        case _15 = 15
+    }
+
+    enum Weight: String {
+        case heavy = "Heavy"
+        case bold = "Bold"
+        case regular = "Regular"
+        case light = "Light"
+
+        var real: UIFont.Weight {
+            switch self {
+            case .heavy:
+                return .heavy
+                
+            case .bold:
+                return .bold
+                
+            case .regular:
+                return .regular
+                
+            case .light:
+                return .light
+            }
+        }
+    }
+
+    struct CustomFont {
+        private let _name: Name
+        private let _weight: Weight
+
+        init(name: Name, weight: Weight) {
+            self._name = name
+            self._weight = weight
+        }
+
+        var name: String {
+            "\(_name.rawValue)TTF\(_weight.rawValue)"
+        }
+
+        var `extension`: String {
+            "ttf"
+        }
+    }
+
+    /// 모든 폰트 파일을 등록합니다.
+    /// 앱 실행 시 최초 한번만 호출합니다.
+    static func registerFonts() {
+        fonts.forEach { font in
+            Font.registerFont(fontName: font.name, fontExtension: font.extension)
+        }
+    }
+}
+
+extension Font {
+    static var fonts: [CustomFont] {
+        [
+            // TODO: 사용할 폰트를 아래 형태와 같이 추가할 예정입니다.
+            // CustomFont(name: <#T##Name#>, weight: <#T##Weight#>)
+        ]
+    }
+
+    private static func registerFont(fontName: String, fontExtension: String) {
+        guard let fontURL = Bundle(identifier: "com.TriT.DesignSystem")?.url(forResource: fontName, withExtension: fontExtension),
+              let fontDataProvider = CGDataProvider(url: fontURL as CFURL),
+              let font = CGFont(fontDataProvider) else {
+            debugPrint("Couldn't create font from filename: \(fontName) with extension \(fontExtension)")
+            return
+        }
+
+        var error: Unmanaged<CFError>?
+        CTFontManagerRegisterGraphicsFont(font, &error)
+    }
+}

--- a/Sources/DesignSystem/Font/Font.swift
+++ b/Sources/DesignSystem/Font/Font.swift
@@ -76,7 +76,7 @@ extension Font {
     }
 
     private static func registerFont(fontName: String, fontExtension: String) {
-        guard let fontURL = Bundle(identifier: "com.TriT.DesignSystem")?.url(forResource: fontName, withExtension: fontExtension),
+        guard let fontURL = Bundle(identifier: "com.Try-ing.MatStar")?.url(forResource: fontName, withExtension: fontExtension),
               let fontDataProvider = CGDataProvider(url: fontURL as CFURL),
               let font = CGFont(fontDataProvider) else {
             debugPrint("Couldn't create font from filename: \(fontName) with extension \(fontExtension)")

--- a/Sources/Presenter/Home/HomeTestViewController.swift
+++ b/Sources/Presenter/Home/HomeTestViewController.swift
@@ -18,6 +18,8 @@ final class HomeTestViewController: BaseViewController {
     private lazy var viewLabel: UILabel = {
         let label = UILabel()
         label.text = "Home"
+        label.font = .designSystem(weight: .heavy, size: ._15)
+        label.textColor = .designSystem(.mainYellow)
         return label
     }()
     

--- a/Sources/Utility/Extensions/CGColor+.swift
+++ b/Sources/Utility/Extensions/CGColor+.swift
@@ -1,0 +1,15 @@
+//
+//  CGColor+.swift
+//  MatStar
+//
+//  Created by 김승창 on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+
+extension CGColor {
+    class func designSystem(_ color: Palette) -> CGColor? {
+        UIColor(named: color.rawValue)?.cgColor
+    }
+}

--- a/Sources/Utility/Extensions/ExtensionDummy.swift
+++ b/Sources/Utility/Extensions/ExtensionDummy.swift
@@ -1,9 +1,0 @@
-//
-//  ExtensionDummy.swift
-//  MatStar
-//
-//  Created by 김승창 on 2022/10/11.
-//  Copyright © 2022 Try-ing. All rights reserved.
-//
-
-import Foundation

--- a/Sources/Utility/Extensions/UIColor+.swift
+++ b/Sources/Utility/Extensions/UIColor+.swift
@@ -11,6 +11,5 @@ import UIKit
 extension UIColor {
     class func designSystem(_ color: Palette) -> UIColor? {
         UIColor(named: color.rawValue)
-//        UIColor(named: color.rawValue, in: Bundle.module, compatibleWith: nil)
     }
 }

--- a/Sources/Utility/Extensions/UIColor+.swift
+++ b/Sources/Utility/Extensions/UIColor+.swift
@@ -1,0 +1,16 @@
+//
+//  UIColor+.swift
+//  MatStar
+//
+//  Created by 김승창 on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+
+extension UIColor {
+    class func designSystem(_ color: Palette) -> UIColor? {
+        UIColor(named: color.rawValue)
+//        UIColor(named: color.rawValue, in: Bundle.module, compatibleWith: nil)
+    }
+}

--- a/Sources/Utility/Extensions/UIFont+.swift
+++ b/Sources/Utility/Extensions/UIFont+.swift
@@ -1,0 +1,22 @@
+//
+//  UIFont+.swift
+//  MatStar
+//
+//  Created by 김승창 on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+
+extension UIFont {
+    class func designSystem(weight: Font.Weight, size: Font.Size) -> UIFont {
+        .systemFont(ofSize: size.rawValue, weight: weight.real)
+    }
+    
+    private static func _font(name: String, size: CGFloat) -> UIFont {
+        guard let font = UIFont(name: name, size: size) else {
+            return .systemFont(ofSize: size)
+        }
+        return font
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#22 Color, Font 추가

## 📝 작업사항
- DesignSystem에 Font, Color를 추가하였습니다.
  - Font는 아직 적용한 것이 없고, Color는 가장 많이 쓸 것 같은 `mainYellow`, `grayC5C5C5` 2개만 추가하였습니다.
- UIFont, UIColor, CGColor extension을 추가하였습니다.
- Resource 디렉토리에 Color Asset을 추가하였습니다.
- SwiftLint 수정하였습니다. (identifier_name, indentation_width)
  - identifier_name : underscore로 시작하려면 변수의 접근지정자가 private일 때만 허용되었는데, Font 적용 시 size에 대한 변수명을 짓기가 힘들어 underscore 검사 조건은 예외로 하였습니다.
  - indentation_width : 4칸의 띄어쓰기를 강제하면 가독성이 좋아질 줄 알았는데, 아래와 같은 상황에서 Xcode가 자동으로 지원하는 indentation이 더 가독성이 좋아 rule을 삭제하게 되었습니다.

```swift
guard let fontURL = Bundle(identifier: "com.TriT.DesignSystem")?.url(forResource: fontName, withExtension: fontExtension),
      let fontDataProvider = CGDataProvider(url: fontURL as CFURL),
      let font = CGFont(fontDataProvider) else {
    debugPrint("Couldn't create font from filename: \(fontName) with extension \(fontExtension)")
    return
}
```


## 📸 스크린샷 또는 영상
### Font, Color 적용 스크린샷
<p>
  <img src="https://user-images.githubusercontent.com/88371913/195798129-0ffb99b2-d66f-455e-9736-bf4e9e2cd848.png" width="300">
</p>
