### PR TITLE
✨ [로그인] -> [이메일 입력] 화면전환 

### DIFF
--- a/Sources/Presenter/Intro/EnterEmail/EnterEmailViewController.swift
+++ b/Sources/Presenter/Intro/EnterEmail/EnterEmailViewController.swift
@@ -13,7 +13,16 @@ import CancelBag
 import SnapKit
 
 final class EnterEmailViewController: BaseViewController {
-    var viewModel: EnterEmailViewModel?
+    let viewModel: EnterEmailViewModel
+
+    init(viewModel: EnterEmailViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     private func bind() {}
 
@@ -32,11 +41,7 @@ extension EnterEmailViewController {
         setLayout()
     }
 
-    private func setAttributes() {
-        
-    }
+    private func setAttributes() {}
 
-    private func setLayout() {
-        
-    }
+    private func setLayout() {}
 }

--- a/Sources/Presenter/Intro/EnterEmail/EnterEmailViewController.swift
+++ b/Sources/Presenter/Intro/EnterEmail/EnterEmailViewController.swift
@@ -1,0 +1,42 @@
+//
+//  EnterEmailViewController.swift
+//  MatStar
+//
+//  Created by Jaeyong Lee on 2022/10/14.
+//  Copyright (c) 2022 Try-ing. All rights reserved.
+//
+
+import Combine
+import UIKit
+
+import CancelBag
+import SnapKit
+
+final class EnterEmailViewController: BaseViewController {
+    var viewModel: EnterEmailViewModel?
+
+    private func bind() {}
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        bind()
+    }
+}
+
+// MARK: - UI
+extension EnterEmailViewController {
+    private func setUI() {
+        setAttributes()
+        setLayout()
+    }
+
+    private func setAttributes() {
+        
+    }
+
+    private func setLayout() {
+        
+    }
+}

--- a/Sources/Presenter/Intro/EnterEmail/EnterEmailViewModel.swift
+++ b/Sources/Presenter/Intro/EnterEmail/EnterEmailViewModel.swift
@@ -10,6 +10,12 @@ import Combine
 
 import CancelBag
 
-final class EnterEmailViewModel: BaseViewModel {
+protocol EnterEmailCoordinatorLogic {}
 
+final class EnterEmailViewModel: BaseViewModel {
+    let coordinator: EnterEmailCoordinatorLogic
+
+    init(coordinator: EnterEmailCoordinatorLogic) {
+        self.coordinator = coordinator
+    }
 }

--- a/Sources/Presenter/Intro/EnterEmail/EnterEmailViewModel.swift
+++ b/Sources/Presenter/Intro/EnterEmail/EnterEmailViewModel.swift
@@ -1,0 +1,15 @@
+//
+//  EnterEmailViewModel.swift
+//  MatStar
+//
+//  Created by Jaeyong Lee on 2022/10/14.
+//  Copyright (c) 2022 Try-ing. All rights reserved.
+//
+
+import Combine
+
+import CancelBag
+
+final class EnterEmailViewModel: BaseViewModel {
+
+}

--- a/Sources/Presenter/Intro/IntroCoordinator.swift
+++ b/Sources/Presenter/Intro/IntroCoordinator.swift
@@ -8,7 +8,13 @@
 
 import UIKit
 
-final class IntroCoordinator: Coordinator {
+protocol IntroCoordinatorProtocol: Coordinator, LoginCoordinatorLogic, EnterEmailCoordinatorLogic {
+    var navigationController: UINavigationController? { get }
+
+    func coordinateToEnterEmailScene()
+}
+
+final class IntroCoordinator: IntroCoordinatorProtocol {
     weak var navigationController: UINavigationController?
 
     init(navigationController: UINavigationController?) {
@@ -21,7 +27,8 @@ final class IntroCoordinator: Coordinator {
     }
 
     func createLoginScene() -> UIViewController {
-        LoginViewController(viewModel: .init(coordinator: self))
+        let loginViewModel = LoginViewModel(coordinator: self)
+        return LoginViewController(viewModel: loginViewModel)
     }
 
     func createEnterEmailScene() -> UIViewController {
@@ -30,7 +37,7 @@ final class IntroCoordinator: Coordinator {
 }
 
 // MARK: - CoordinatorLogic
-extension IntroCoordinator: LoginCoordinatorLogic, EnterEmailCoordinatorLogic {
+extension IntroCoordinator {
 
     func coordinateToEnterEmailScene() {
         navigationController?.setNavigationBarHidden(false, animated: false)

--- a/Sources/Presenter/Intro/IntroCoordinator.swift
+++ b/Sources/Presenter/Intro/IntroCoordinator.swift
@@ -16,7 +16,24 @@ final class IntroCoordinator: Coordinator {
     }
 
     func start() {
-        let controller = LoginViewController()
-        self.navigationController?.setViewControllers([controller], animated: false)
+        let startController = createLoginScene()
+        navigationController?.setViewControllers([startController], animated: false)
+    }
+
+    func createLoginScene() -> UIViewController {
+        LoginViewController(viewModel: .init(coordinator: self))
+    }
+
+    func createEnterEmailScene() -> UIViewController {
+        EnterEmailViewController(viewModel: .init(coordinator: self))
+    }
+}
+
+// MARK: - CoordinatorLogic
+extension IntroCoordinator: LoginCoordinatorLogic, EnterEmailCoordinatorLogic {
+
+    func coordinateToEnterEmailScene() {
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        navigationController?.pushViewController(createEnterEmailScene(), animated: true)
     }
 }

--- a/Sources/Presenter/Intro/Login/LoginViewController.swift
+++ b/Sources/Presenter/Intro/Login/LoginViewController.swift
@@ -15,9 +15,9 @@ import PinLayout
 import FlexLayout
 
 final class LoginViewController: BaseViewController {
-    let viewModel: LoginViewModel
+    let viewModel: LoginBusinessLogic
 
-    init(viewModel: LoginViewModel) {
+    init(viewModel: LoginBusinessLogic) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
@@ -66,7 +66,7 @@ extension LoginViewController {
 extension LoginViewController {
 
     @objc
-    private func loginBttonDidTapped() {
+    func loginBttonDidTapped() {
         viewModel.loginButtonDidTapped()
     }
 }

--- a/Sources/Presenter/Intro/Login/LoginViewController.swift
+++ b/Sources/Presenter/Intro/Login/LoginViewController.swift
@@ -15,11 +15,18 @@ import PinLayout
 import FlexLayout
 
 final class LoginViewController: BaseViewController {
-    var viewModel: LoginViewModel?
-    
-    private func bind() {
+    let viewModel: LoginViewModel
 
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
     }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func bind() {}
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,11 +34,39 @@ final class LoginViewController: BaseViewController {
         setUI()
         bind()
     }
+
+    lazy var loginButton: UIButton = UIButton(type: .system)
 }
 
 // MARK: - UI
 extension LoginViewController {
     private func setUI() {
+        setAttribute()
+        setLayout()
+    }
 
+    private func setAttribute() {
+        loginButton.setTitle("이메일로 로그인", for: .normal)
+        loginButton.setTitleColor(.black, for: .normal)
+        loginButton.layer.borderColor = UIColor.black.cgColor
+        loginButton.layer.borderWidth = 1
+        loginButton.layer.cornerRadius = 15
+        loginButton.layer.masksToBounds = true
+        loginButton.addTarget(self, action: #selector(loginBttonDidTapped), for: .touchUpInside)
+    }
+
+    private func setLayout() {
+        view.addSubview(loginButton)
+
+        loginButton.pin.left().right().margin(20).bottom(100).height(60)
+    }
+}
+
+// MARK: Button Clicked
+extension LoginViewController {
+
+    @objc
+    private func loginBttonDidTapped() {
+        viewModel.loginButtonDidTapped()
     }
 }

--- a/Sources/Presenter/Intro/Login/LoginViewModel.swift
+++ b/Sources/Presenter/Intro/Login/LoginViewModel.swift
@@ -10,6 +10,18 @@ import Combine
 
 import CancelBag
 
-final class LoginViewModel: BaseViewModel {
+protocol LoginCoordinatorLogic {
+    func coordinateToEnterEmailScene()
+}
 
+final class LoginViewModel: BaseViewModel {
+    let coordinator: LoginCoordinatorLogic
+
+    init(coordinator: LoginCoordinatorLogic) {
+        self.coordinator = coordinator
+    }
+
+    func loginButtonDidTapped() {
+        coordinator.coordinateToEnterEmailScene()
+    }
 }

--- a/Sources/Presenter/Intro/Login/LoginViewModel.swift
+++ b/Sources/Presenter/Intro/Login/LoginViewModel.swift
@@ -14,7 +14,11 @@ protocol LoginCoordinatorLogic {
     func coordinateToEnterEmailScene()
 }
 
-final class LoginViewModel: BaseViewModel {
+protocol LoginBusinessLogic {
+    func loginButtonDidTapped()
+}
+
+final class LoginViewModel: BaseViewModel, LoginBusinessLogic {
     let coordinator: LoginCoordinatorLogic
 
     init(coordinator: LoginCoordinatorLogic) {

--- a/Tests/Intro/IntroCoordinatorTests.swift
+++ b/Tests/Intro/IntroCoordinatorTests.swift
@@ -1,0 +1,36 @@
+//
+//  IntroCoordinatorTests.swift
+//  MatStarTests
+//
+//  Created by Jaeyong Lee on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import XCTest
+@testable import MatStar
+
+final class IntroCoordinatorTests: XCTestCase {
+    var sut: IntroCoordinatorProtocol!
+    var mockNavigationController: MockNavigationController!
+
+    override func setUp() {
+        super.setUp()
+        mockNavigationController = MockNavigationController(rootViewController: .init())
+        sut = IntroCoordinator(navigationController: mockNavigationController)
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    func testIntroCoordinator_이메일입력_화면으로_전환합니다() {
+        // when
+        sut.coordinateToEnterEmailScene()
+
+        // then
+        XCTAssertEqual(mockNavigationController.pushViewControllerCalled, true)
+        XCTAssertTrue(mockNavigationController.pushedViewController is EnterEmailViewController)
+    }
+
+}

--- a/Tests/Intro/LoginViewControllerTests.swift
+++ b/Tests/Intro/LoginViewControllerTests.swift
@@ -1,0 +1,31 @@
+//
+//  LoginViewControllerTests.swift
+//  MatStarTests
+//
+//  Created by Jaeyong Lee on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import XCTest
+@testable import MatStar
+
+final class LoginViewControllerTests: XCTestCase {
+
+    var sut: LoginViewController!
+    var mockLoginViewModel: MockLoginViewModel!
+    var mockIntroCoordinator: MockIntroCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        mockIntroCoordinator = MockIntroCoordinator()
+        mockLoginViewModel = MockLoginViewModel(coordinator: mockIntroCoordinator)
+        sut = LoginViewController(viewModel: mockLoginViewModel)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockLoginViewModel = nil
+        mockIntroCoordinator = nil
+        super.tearDown()
+    }
+}

--- a/Tests/Intro/LoginViewModelTests.swift
+++ b/Tests/Intro/LoginViewModelTests.swift
@@ -1,0 +1,36 @@
+//
+//  LoginViewModelTests.swift
+//  MatStarTests
+//
+//  Created by Jaeyong Lee on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+import XCTest
+@testable import MatStar
+
+final class LoginViewModelTests: XCTestCase {
+    var sut: LoginBusinessLogic!
+    var mockIntroCoordinator: MockIntroCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        mockIntroCoordinator = MockIntroCoordinator()
+        sut = LoginViewModel(coordinator: mockIntroCoordinator)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockIntroCoordinator = nil
+        super.tearDown()
+    }
+
+    func testLoginViewModel_이메일로_로그인하기_버튼이_한번_눌리면_코디네이터_화면이_전환됩니다() {
+        // when
+        sut.loginButtonDidTapped()
+
+        // then
+        XCTAssertEqual(mockIntroCoordinator.coordinateToEnterEmailSceneCount, 1)
+    }
+}

--- a/Tests/TestDoubles/IntroCoordinator+Mock.swift
+++ b/Tests/TestDoubles/IntroCoordinator+Mock.swift
@@ -1,0 +1,18 @@
+//
+//  IntroCoordinator+Mock.swift
+//  MatStarTests
+//
+//  Created by Jaeyong Lee on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+@testable import MatStar
+
+final class MockIntroCoordinator: IntroCoordinatorProtocol {
+    var navigationController: UINavigationController?
+    var coordinateToEnterEmailSceneCount: Int = 0
+    func coordinateToEnterEmailScene() {
+        coordinateToEnterEmailSceneCount += 1
+    }
+}

--- a/Tests/TestDoubles/LoginViewModel+Mock.swift
+++ b/Tests/TestDoubles/LoginViewModel+Mock.swift
@@ -1,0 +1,22 @@
+//
+//  LoginViewModel+Mock.swift
+//  MatStarTests
+//
+//  Created by Jaeyong Lee on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import Foundation
+
+@testable import MatStar
+final class MockLoginViewModel: LoginBusinessLogic {
+    var coordinator: LoginCoordinatorLogic
+
+    init(coordinator: LoginCoordinatorLogic) {
+        self.coordinator = coordinator
+    }
+    var loginButtonDidTappedCount: Int = 0
+    func loginButtonDidTapped() {
+        loginButtonDidTappedCount += 1
+    }
+}

--- a/Tests/TestDoubles/NavigationController+Mock.swift
+++ b/Tests/TestDoubles/NavigationController+Mock.swift
@@ -1,0 +1,20 @@
+//
+//  NavigationController+Mock.swift
+//  MatStarTests
+//
+//  Created by Jaeyong Lee on 2022/10/14.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+@testable import MatStar
+
+final class MockNavigationController: UINavigationController {
+    var pushViewControllerCalled: Bool = false
+    var pushedViewController: UIViewController?
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        super.pushViewController(viewController, animated: animated)
+        pushViewControllerCalled = true
+        pushedViewController = viewController
+    }
+}


### PR DESCRIPTION
## 🔍 개요
- #26 

## 📝 작업사항
- 로그인 -> 이메일 입력 화면 전환 구현했습니다. 
- 뷰모델과 코디네이터의 화면전환 로직을 테스트했습니다. 

## 리뷰포인트
화면전환이 잘 되는지에 대한 검토, 그리고 테스트 범위에 대해 이야기 나누면 좋을 듯 해 보여요.
```
테스트 범위 
1. VC의 데이터가 표시되는 UI 상태 
2. 비즈니스로직 (화면전환 포함)
3. 네트워크
```

## 📸 스크린샷 또는 영상

<p>
  <img src="https://user-images.githubusercontent.com/56102421/195881485-66d061f4-bd9f-4c48-9a83-1a346d78621c.gif" width="300">
</p>

## 🧐 참고 사항

컴포넌트 구성은 폰트 추가된 이후에 진행할게여~ 기능 먼저 개발하고 있겠슴다