### PR TITLE
✨ 오류처리되는 텍스트필드 뷰 컴포넌트 

### DIFF
--- a/Sources/DesignSystem/Protocols/Component.swift
+++ b/Sources/DesignSystem/Protocols/Component.swift
@@ -1,0 +1,11 @@
+//
+//  Component.swift
+//  MatStar
+//
+//  Created by Jaeyong Lee on 2022/10/15.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+
+protocol Component: UIView {}

--- a/Sources/DesignSystem/Protocols/TextFieldWithMessageViewComponent.swift
+++ b/Sources/DesignSystem/Protocols/TextFieldWithMessageViewComponent.swift
@@ -1,0 +1,16 @@
+//
+//  TextFieldErrorable.swift
+//  MatStar
+//
+//  Created by Jaeyong Lee on 2022/10/15.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+
+protocol TextFieldWithMessageViewComponent: Component {
+    var delegate: TextFieldWithMessageViewComponentDelegate? { get set }
+    /// 에러메시지를 보여주는 함수
+    /// - Parameter direction:성공, 실패 
+    func showError(type errorType: IntroErrorType)
+}

--- a/Sources/DesignSystem/Views/TextFieldWithMessageView.swift
+++ b/Sources/DesignSystem/Views/TextFieldWithMessageView.swift
@@ -1,0 +1,152 @@
+//
+//  TextFieldWithMessageView.swift
+//  MatStarTests
+//
+//  Created by Jaeyong Lee on 2022/10/15.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+
+import PinLayout
+
+protocol TextFieldWithMessageViewComponentDelegate: AnyObject {
+    /// 텍스트가 입력되는 실시간 함수
+    /// - Parameter text: 텍스트
+    func textFieldDidChange(_ text: String)
+}
+
+final class TextFieldWithMessageView: UIView {
+    private let failColor: UIColor? = .red
+    private let successColor: UIColor? = .green
+    private let normalColor: UIColor? = .clear
+
+    enum TextType {
+        case nickname
+        case password
+        case email
+        case certificationNumber
+        case noText
+    }
+
+    private var textType: TextType
+    weak var delegate: TextFieldWithMessageViewComponentDelegate?
+
+    convenience init(textType: TextType) {
+        self.init(frame: .zero)
+        self.textType = textType
+        self.textField.placeholder = textType.placeholder
+    }
+
+    override init(frame: CGRect) {
+        self.textType = .noText
+        super.init(frame: frame)
+
+        setUI()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    lazy var textField = UITextField()
+    lazy var errorLabel = UILabel()
+}
+
+// MARK: - TextFieldErrorable
+extension TextFieldWithMessageView: TextFieldWithMessageViewComponent {
+
+    func showError(type errorType: IntroErrorType) {
+        errorLabel.isHidden = errorType == .noError
+        errorLabel.textColor = errorType.color
+        errorLabel.text = errorType.message
+        textField.layer.borderColor = errorType.color?.cgColor
+        textField.layer.borderWidth = 1
+    }
+
+    @objc
+    func textFieldDidchange(_ textField: UITextField) {
+        guard let text = textField.text else {
+            return
+        }
+        delegate?.textFieldDidChange(text)
+    }
+}
+
+// MARK: - UI
+extension TextFieldWithMessageView {
+    private func setUI() {
+        addSubviews()
+        setAttribute()
+        setLayout()
+    }
+
+    private func setAttribute() {
+        errorLabel.textColor = normalColor
+        errorLabel.font = .boldSystemFont(ofSize: 12)
+        textField.addTarget(self, action: #selector(textFieldDidchange), for: .editingChanged)
+        textField.backgroundColor = UIColor(red: 0.3, green: 0.3, blue: 0.3, alpha: 1)
+        textField.textColor = .white
+        textField.leftView = UIView()
+        textField.leftViewMode = .always
+        textField.leftView?.pin.width(15)
+        textField.layer.cornerRadius = 15
+        textField.layer.masksToBounds = true
+
+        self.setClearButton()
+    }
+
+    private func setClearButton() {
+        let clearButtonWrappedView = UIView(frame: CGRect(origin: .zero, size: .init(width: 30, height: 20)))
+        let clearButton = UIButton(type: .system)
+        let image = UIImage(systemName: "xmark.circle.fill")?.withTintColor(.black)
+        clearButton.setImage(image, for: .normal)
+        clearButton.addTarget(self, action: #selector(clearButtonDidTap), for: .touchUpInside)
+        clearButton.tintColor = .black
+        clearButtonWrappedView.addSubview(clearButton)
+        clearButton.pin.top().bottom().left().width(20)
+        textField.rightView = clearButtonWrappedView
+        textField.clearButtonMode = .never
+        textField.rightViewMode = .whileEditing
+    }
+
+    @objc
+    func clearButtonDidTap() {
+        self.textField.text?.removeAll()
+    }
+
+    private func addSubviews() {
+        addSubview(textField)
+        addSubview(errorLabel)
+    }
+
+    private func setLayout() {
+        textField.pin.top().left().right().height(50)
+        errorLabel.pin.below(of: textField).left().right().margin(3, 8, 8).height(15)
+    }
+}
+
+// MARK: - Constants
+extension TextFieldWithMessageView.TextType {
+
+    var placeholder: String? {
+        switch self {
+        case .nickname:
+            return "닉네임을 입력해 주세요."
+        case .password:
+            return "비밀번호를 입력해 주세요."
+        case .email:
+            return "이메일을 입력해 주세요."
+        case .certificationNumber:
+            return "인증번호를 입력해 주세요."
+        case .noText:
+            return ""
+        }
+    }
+}

--- a/Sources/DesignSystem/Views/TextFieldWithMessageView.swift
+++ b/Sources/DesignSystem/Views/TextFieldWithMessageView.swift
@@ -16,6 +16,19 @@ protocol TextFieldWithMessageViewComponentDelegate: AnyObject {
     func textFieldDidChange(_ text: String)
 }
 
+/*
+    사용방법
+```
+    let view: TextFieldWithMessageViewComponent = TextFieldWithMessageView()
+    view.delegate = self
+    // TextFieldWithMessageViewComponentDelegate 채택
+    view.snp.makeConstraints { make in
+        make.top.left.right.equalToSuperView()
+    }
+```
+*/
+/// 높이는 68로 고정되어 있습니다.
+/// 위, 왼쪽, 오른쪽을 잡아주세요.
 final class TextFieldWithMessageView: UIView {
     private let failColor: UIColor? = .red
     private let successColor: UIColor? = .green
@@ -129,6 +142,7 @@ extension TextFieldWithMessageView {
     private func setLayout() {
         textField.pin.top().left().right().height(50)
         errorLabel.pin.below(of: textField).left().right().margin(3, 8, 8).height(15)
+        self.pin.height(68) // = 50 + 3 + 15
     }
 }
 

--- a/Sources/Presenter/Intro/IntroErrorType.swift
+++ b/Sources/Presenter/Intro/IntroErrorType.swift
@@ -1,0 +1,44 @@
+//
+//  IntroErrorType.swift
+//  MatStar
+//
+//  Created by Jaeyong Lee on 2022/10/15.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import UIKit
+
+enum IntroErrorType {
+    case invalidEmail // 이메일 정보가 올바르지 않은 경우
+    case invalidPassword //
+    case wrongPassword // 잘못된 비밀번호를 입력했을 경우
+    case wrongCertificationNumber // 인증번호가 올바르지 못한 경우
+    case noUser // 등록되지 않은 유저인 경우
+    case noError // 에러가 없는 경우
+
+    var message: String? {
+        switch self {
+        case .invalidEmail:
+            return "올바른 이메일 주소가 아닙니다."
+        case .invalidPassword:
+            return "한글 + 영어 + 숫자  포함 8자 이내"
+        case .wrongPassword:
+            return "비밀번호가 틀렸습니다."
+        case .wrongCertificationNumber:
+            return "인증번호가 틀렸습니다!"
+        case .noUser:
+            return "등록된 정보가 없습니다."
+        case .noError:
+            return nil
+        }
+    }
+
+    var color: UIColor? {
+        switch self {
+        case .noError:
+            return .green
+        default:
+            return .red
+        }
+    }
+}

--- a/Tests/DesignSystem/TextFieldWithMessageViewTests.swift
+++ b/Tests/DesignSystem/TextFieldWithMessageViewTests.swift
@@ -1,0 +1,66 @@
+//
+//  TextFieldWithMessageViewTests.swift
+//  MatStarTests
+//
+//  Created by Jaeyong Lee on 2022/10/15.
+//  Copyright © 2022 Try-ing. All rights reserved.
+//
+
+import XCTest
+@testable import MatStar
+
+final class TextFieldWithMessageViewTests: XCTestCase {
+
+    var sut: TextFieldWithMessageView!
+
+    override func setUp() {
+        super.setUp()
+        sut = TextFieldWithMessageView()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    func testTextFieldWithMessageView_이메일_텍스트필드를_생성합니다() {
+        let textType = TextFieldWithMessageView.TextType.email
+        sut = TextFieldWithMessageView(textType: textType)
+        XCTAssertEqual(sut.textField.placeholder, textType.placeholder)
+    }
+
+    func testTextFieldWithMessageView_닉네임_텍스트필드를_생성합니다() {
+        let textType = TextFieldWithMessageView.TextType.nickname
+        sut = TextFieldWithMessageView(textType: textType)
+        XCTAssertEqual(sut.textField.placeholder, textType.placeholder)
+    }
+
+    func testTextFieldWithMessageView_인증번호_텍스트필드를_생성합니다() {
+        let textType = TextFieldWithMessageView.TextType.certificationNumber
+        sut = TextFieldWithMessageView(textType: textType)
+        XCTAssertEqual(sut.textField.placeholder, textType.placeholder)
+    }
+
+    func testTextFieldWithMessageView_비밀번호_텍스트필드를_생성합니다() {
+        let textType = TextFieldWithMessageView.TextType.password
+        sut = TextFieldWithMessageView(textType: textType)
+        XCTAssertEqual(sut.textField.placeholder, textType.placeholder)
+    }
+
+    func testTextFieldWithMessageView_이메일_validation_오류메시지가_발생했습니다() {
+        let error = IntroErrorType.invalidEmail
+        sut.showError(type: error)
+        XCTAssertEqual(sut.errorLabel.text, error.message)
+        XCTAssertEqual(sut.errorLabel.textColor, error.color)
+        XCTAssertEqual(sut.textField.layer.borderColor, error.color?.cgColor)
+    }
+
+    func testTextFieldWithMessageView_텍스트_clear버튼을_누르면_텍스트가_모두_사라집니다() {
+        // given
+        sut.textField.text = "유저가 쓴 텍스트"
+        // when
+        sut.clearButtonDidTap()
+        // then
+        XCTAssertEqual(sut.textField.text, "")
+    }
+}


### PR DESCRIPTION
## 🔍 개요
- #32 

## 📝 작업사항
- 아래 오류메시지가 나오는 컴포넌트 구현했습니다. (테스트 일부 완료) 
- 이메일, 비밀번호, 닉네임, 인증번호 textField를 만들었습니다. (테스트 완료)
- textField의 clear버튼의 색상과 위치가 기존 구현된 clear버튼과 달라 커스텀했습니다. (테스트 완료)

### 사용방법 
> 아마도 나만 사용할듯 😅 
```swift
let view: TextFieldWithMessageViewComponent = TextFieldWithMessageView()
view.delegate = self
// TextFieldWithMessageViewComponentDelegate 채택
view.snp.makeConstraints { make in // SnapKit 사용 시
    make.top.left.right.equalToSuperView()
}
```


## 📸 스크린샷 또는 영상


| 오류 | 일반 |
| ---------------------------- | ---------------------------------- |
| <img width="421" alt="스크린샷 2022-10-15 오후 4 08 51" src="https://user-images.githubusercontent.com/56102421/195994618-d81a7b31-0a64-47a8-bfba-73c53e03b98f.png"> | <img width="405" alt="스크린샷 2022-10-15 오후 4 08 16" src="https://user-images.githubusercontent.com/56102421/195994632-2801370b-83df-4808-8e2e-3e66ff2e9551.png"> |


## 🧐 참고 사항

- https://designcompass.org/2022/01/16/cell-design-system/