### PR TITLE
♻️ 홈뷰 애니메이션 전체수정 및 주석추가

### DIFF
--- a/Sources/Presenter/Home/MyHome/View/HomeDetailView.swift
+++ b/Sources/Presenter/Home/MyHome/View/HomeDetailView.swift
@@ -190,7 +190,7 @@ class HomeDetailView: UIView {
         
         myPlanetImage.snp.makeConstraints { make in
             let bounds = UIScreen.main.bounds
-            make.centerY.equalTo(self.snp.bottom)
+            make.centerY.equalTo(self.snp.bottom).inset(20)
             make.centerX.equalToSuperview()
             make.width.equalTo(bounds.width * 1.2)
             make.height.equalTo(bounds.width * 1.2)

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -47,7 +47,13 @@ final class HomeViewController: BaseViewController {
         setAttributes()
     }
     
-    func changeMyPlanet(center: CGPoint, myPlanetTransform: CGAffineTransform, constellationAlpha: CGFloat) {
+    
+    /// pangesture에 따라서 요소들을 변화시키는 함수
+    /// - Parameters:
+    ///   - center: 이미지의 center좌표
+    ///   - myPlanetTransform: 어떻게 변할지, 주로 scale에 관한 값
+    ///   - constellationAlpha: 제스처에따라 alpha값이 변하는 요소는 어떻값으로 변할지
+    private func changeMyPlanet(center: CGPoint, myPlanetTransform: CGAffineTransform, constellationAlpha: CGFloat) {
         self.homeDetailView.myPlanetImage.center = center
         self.homeDetailView.myPlanetImage.transform = myPlanetTransform
         self.homeDetailView.constellationCollectionView.alpha = constellationAlpha
@@ -62,10 +68,9 @@ final class HomeViewController: BaseViewController {
         gesture.setTranslation(.zero, in: myPlanet)
         if gesture.state == .changed {
             if abs(gesture.velocity(in: myPlanet).y) > abs(gesture.velocity(in: myPlanet).x) {
-                changeMyPlanet(center: CGPoint(x: imageCenterX,
-                                               y: min(max(imageCenterY + translation.y, screenHeight/2), screenHeight)),
-                               myPlanetTransform: CGAffineTransform(scaleX: changeScale(xPoint: imageCenterY), y: changeScale(xPoint: imageCenterY)),
-                               constellationAlpha: changeAlpht(xPoint: imageCenterY))
+                changeMyPlanet(center: CGPoint(x: imageCenterX, y: min(max(imageCenterY + translation.y, screenHeight/2), screenHeight)),
+                               myPlanetTransform: CGAffineTransform(scaleX: changeScale(yPoint: imageCenterY), y: changeScale(yPoint: imageCenterY)),
+                               constellationAlpha: changeAlpha(yPoint: imageCenterY))
             }
         } else if gesture.state == .ended {
             if imageCenterY > screenHeight * 6/7 {
@@ -95,8 +100,8 @@ final class HomeViewController: BaseViewController {
         if gesture.state == .changed {
             if abs(gesture.velocity(in: myPlanet).y) > abs(gesture.velocity(in: myPlanet).x) {
                 changeMyPlanet(center: CGPoint(x: imageCenterX, y: min(max(imageCenterY + translation.y, screenHeight/2), screenHeight)),
-                               myPlanetTransform: CGAffineTransform(scaleX: changeScale(xPoint: imageCenterY), y: changeScale(xPoint: imageCenterY)),
-                               constellationAlpha: changeAlpht(xPoint: imageCenterY))
+                               myPlanetTransform: CGAffineTransform(scaleX: changeScale(yPoint: imageCenterY), y: changeScale(yPoint: imageCenterY)),
+                               constellationAlpha: changeAlpha(yPoint: imageCenterY))
                 self.homeDetailView.constellationCollectionView.isHidden = false
             }
         } else if gesture.state == .ended {
@@ -129,12 +134,25 @@ final class HomeViewController: BaseViewController {
         viewModel.pushToAlarmView()
     }
     
-    func changeScale(xPoint: Double) -> CGFloat {
-        return CGFloat(((xPoint * 0.5)/425)+0.0287)
+    /// 이미지의 center위치(y)값에 따라 곱해줄 scale값을 return해주는 함수
+    /// - Parameter yPoint: 이미지center의 yPoint
+    /// - Returns: 이미지에 곱해줄 scale값
+    private func changeScale(yPoint: Double) -> CGFloat {
+        // 기울기(기기의 크기별로 대응되도록 계산)
+        let gradient = (2*(1 - changeMyPlanetScale))/screenHeight
+        // 그래프의 y절편(1차함수기때문에 필요)
+        let interceptionY = (2 * changeMyPlanetScale) - 1
+        return CGFloat((gradient * yPoint) + interceptionY)
     }
     
-    func changeAlpht(xPoint: Double) -> CGFloat {
-        return CGFloat((xPoint/400)-1.1125)
+    
+    /// 이미지의 center(y)값에 따라 곱해줄 alpha값을 return해주는 함수
+    /// - Parameter yPoint: 이미지center의 yPoint
+    /// - Returns: 이미지에 곱해줄 alpha값
+    private func changeAlpha(yPoint: Double) -> CGFloat {
+        let gredient = 2/screenHeight
+        let interceptionY = -1.0
+        return CGFloat((gredient * yPoint) + interceptionY)
     }
 }
 


### PR DESCRIPTION
## 🔍 개요
#60

## 📝 작업사항
이전 version
- 애니메이션에 제약조건이 없었음(아래로 드래그는 못함(터치해야 지구내려옴), 드래그하면 aplha값이 안변함, 휴대폰 밑으로 지구가 내려감)
- 드래그를 해서 옮기는게 아닌 드래그를 하는 순간 이미 지구는 줄어들어서 가운데로 붙어버림
- 사용자의 드래그 포인트마다 지구크기가 변하지 않음(정해진 크기로 바로 변해버림)
- alpha값이 static하게 변함
- 지구 이미지와 드래그가 따로놈

바뀐 version
- 애니메이션 제약조건이 생김(지구가 올라가고 내려감)
- 터치이벤트 없애고 전부다 드래그 이벤트로 바꿈(올라갈때는 드래그인데 내려갈때는 터치인게 이상함)
- 지구가 화면 중간이상으로 안올라가고 지구가 화면 밖으로 나가지 않음(아래로)
- 사용자의 드래그 포인트마다 지구크기가 유동적으로 변함
- alpha값이 유동적으로 변함
- 지구 이미지와 드래그가 같이 변함


## 📸 스크린샷 또는 영상
https://www.notion.so/10-21-Daily-standup-535ed8838b9346d6a8414f7558cdc411
영상이 커서 노션으로 대체
- 유쓰 section에서 확인

## 🧐 참고 사항 - scale과 alpha값 유동적으로 변하게 하는 함수
```swift
    /// 이미지의 center위치(y)값에 따라 곱해줄 scale값을 return해주는 함수
    /// - Parameter yPoint: 이미지center의 yPoint
    /// - Returns: 이미지에 곱해줄 scale값
    private func changeScale(yPoint: Double) -> CGFloat {
        // 기울기(기기의 크기별로 대응되도록 계산)
        let gradient = (2*(1 - changeMyPlanetScale))/screenHeight
        // 그래프의 y절편(1차함수기때문에 필요)
        let interceptionY = (2 * changeMyPlanetScale) - 1
        return CGFloat((gradient * yPoint) + interceptionY)
    }
    
    
    /// 이미지의 center(y)값에 따라 곱해줄 alpha값을 return해주는 함수
    /// - Parameter yPoint: 이미지center의 yPoint
    /// - Returns: 이미지에 곱해줄 alpha값
    private func changeAlpha(yPoint: Double) -> CGFloat {
        let gredient = 2/screenHeight
        let interceptionY = -1.0
        return CGFloat((gredient * yPoint) + interceptionY)
    }
```

