### PR TITLE
🔮 로그인 이미지 위치 및 콘텐츠모드 수정

### DIFF
--- a/Sources/Presenter/Intro/Scenes/Login/LoginViewController.swift
+++ b/Sources/Presenter/Intro/Scenes/Login/LoginViewController.swift
@@ -44,6 +44,7 @@ final class LoginViewController: PlanetAnimatedViewController<LoginViewModel> {
         signUpButton.addTarget(self, action: #selector(signUpButtonDidTapped), for: .touchUpInside)
 
         logoImageView.image = .init(.planets)
+        logoImageView.contentMode = .scaleAspectFill
     }
 
     override func setLayout() {
@@ -59,7 +60,7 @@ final class LoginViewController: PlanetAnimatedViewController<LoginViewModel> {
             make.top.equalTo(view.safeAreaLayoutGuide).offset(26)
         }
         logoImageView.snp.makeConstraints { make in
-            make.top.equalTo(logoLabel.snp.bottom).offset(30)
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(190)
             make.leading.trailing.equalToSuperview()
             make.width.equalTo(logoImageView.snp.height).multipliedBy(436 / 449)
         }


### PR DESCRIPTION
## 🔍 개요
- #109 

## 📝 작업사항
- 제목과 동일합니다. 
- iPhone Pro Max에서 이미지가 깨지고 겹치는 문제를 해결했습니다.


## 📸 스크린샷 또는 영상
<img src="https://user-images.githubusercontent.com/56102421/198499825-571f72b3-8e1d-4c31-b140-ae1b4359c12b.png" width="700">
