### PR TITLE
:sparkles: 타입별로 별자리생성,코스수정 분기처리

### DIFF
--- a/Sources/Presenter/Home/AddCourse/AddCourseCoordinator.swift
+++ b/Sources/Presenter/Home/AddCourse/AddCourseCoordinator.swift
@@ -8,11 +8,6 @@
 
 import UIKit
 
-enum AddCourseFlowType {
-    case plan
-    case record
-}
-
 final class AddCourseCoordinator: Coordinator,
                                   AddCourseMapCoordinating,
                                   PlaceSearchCoordinating,

--- a/Sources/Presenter/Home/MyHome/HomeCoordinator.swift
+++ b/Sources/Presenter/Home/MyHome/HomeCoordinator.swift
@@ -22,6 +22,11 @@ final class HomeCoordinator: Coordinator {
         
         navigationController.pushViewController(viewController, animated: true)
     }
+    
+    func startAddCourseFlow(type: AddCourseFlowType) {
+        let addCourseCoordinator = AddCourseCoordinator(type: type,navigationController: navigationController)
+        addCourseCoordinator.start()
+    }
 }
 
 //extension HomeCoordinator: AlarmViewCoordinating, CourseDetailCoordinating {

--- a/Sources/Presenter/Home/MyHome/HomeCoordinator.swift
+++ b/Sources/Presenter/Home/MyHome/HomeCoordinator.swift
@@ -24,7 +24,7 @@ final class HomeCoordinator: Coordinator {
     }
     
     func startAddCourseFlow(type: AddCourseFlowType) {
-        let addCourseCoordinator = AddCourseCoordinator(type: type,navigationController: navigationController)
+        let addCourseCoordinator = AddCourseCoordinator(type: type, navigationController: navigationController)
         addCourseCoordinator.start()
     }
 }

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -451,7 +451,11 @@ extension HomeViewController: UITableViewDelegate {
 }
 
 extension HomeViewController: ActionSheetDelegate {
-    func registerReviewVC() {
+    func presentModifyViewController() {
+        viewModel.startAddCourseFlow(type: self.selectedDate > Date() ? .editPlan : .editCourse)
+    }
+    
+    func presentRegisterReviewViewController() {
         if self.selectedDate > Date() {
             let alert = UIAlertController(title: "안내", message: "미래의 계획은 후기를 등록할 수 없습니다", preferredStyle: UIAlertController.Style.alert)
             let okAction = UIAlertAction(title: "알겠습니다", style: .default)
@@ -460,10 +464,6 @@ extension HomeViewController: ActionSheetDelegate {
         } else {
             viewModel.startAddCourseFlow(type: .registerReview)
         }
-    }
-    
-    func moveModifyVC() {
-        viewModel.startAddCourseFlow(type: self.selectedDate > Date() ? .editPlan : .editCourse)
     }
 
     func showPathActionSheet(alert: UIAlertController) {

--- a/Sources/Presenter/Home/MyHome/ViewModel/HomeViewModel.swift
+++ b/Sources/Presenter/Home/MyHome/ViewModel/HomeViewModel.swift
@@ -92,3 +92,11 @@ final class HomeViewModel: BaseViewModel {
         dateCourse = HomeCourse(courseTitle: selectedDateCourse.title, courseList: placeList)
     }
 }
+
+// MARK: - Coordinating
+extension HomeViewModel {
+    func startAddCourseFlow(type: AddCourseFlowType) {
+        guard let coordinator = coordinator as? HomeCoordinator else { return }
+        coordinator.startAddCourseFlow(type: type)
+    }
+}

--- a/Sources/Presenter/Home/MyHome/Views/PathTableFooter.swift
+++ b/Sources/Presenter/Home/MyHome/Views/PathTableFooter.swift
@@ -14,7 +14,7 @@ class PathTableFooter: UITableViewHeaderFooterView {
     
     weak var delegate: ActionSheetDelegate?
     
-    private let registerReviewButton: UIButton = {
+    private lazy var registerReviewButton: UIButton = {
         let button = UIButton(type: .system)
         button.backgroundColor = .clear
         button.setImage(UIImage(systemName: "paperplane.fill"), for: .normal)
@@ -28,6 +28,7 @@ class PathTableFooter: UITableViewHeaderFooterView {
         button.tintColor = .designSystem(.mainYellow)
         button.setTitleColor(.designSystem(.mainYellow), for: .normal)
         button.titleLabel?.font = .systemFont(ofSize: 11, weight: .bold)
+        button.addTarget(self, action: #selector(registerButtonTapped), for: .touchUpInside)
         return button
     }()
     
@@ -61,13 +62,20 @@ class PathTableFooter: UITableViewHeaderFooterView {
     @objc
     func settingButtonTapped() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        let modify = UIAlertAction(title: "별자리 수정하기", style: .default)
+        let modify = UIAlertAction(title: "별자리 수정하기", style: .default) { _ in
+            self.delegate?.moveModifyVC()
+        }
         let delete = UIAlertAction(title: "별자리 삭제하기", style: .default)
         let cancel = UIAlertAction(title: "취소", style: .cancel)
         actionSheet.addAction(modify)
         actionSheet.addAction(delete)
         actionSheet.addAction(cancel)
         self.delegate?.showSettingActionSheet(alert: actionSheet)
+    }
+    
+    @objc
+    func registerButtonTapped() {
+        self.delegate?.registerReviewVC()
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/Presenter/Home/MyHome/Views/PathTableFooter.swift
+++ b/Sources/Presenter/Home/MyHome/Views/PathTableFooter.swift
@@ -63,7 +63,7 @@ class PathTableFooter: UITableViewHeaderFooterView {
     func settingButtonTapped() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let modify = UIAlertAction(title: "별자리 수정하기", style: .default) { _ in
-            self.delegate?.moveModifyVC()
+            self.delegate?.presentModifyViewController()
         }
         let delete = UIAlertAction(title: "별자리 삭제하기", style: .default)
         let cancel = UIAlertAction(title: "취소", style: .cancel)
@@ -75,7 +75,7 @@ class PathTableFooter: UITableViewHeaderFooterView {
     
     @objc
     func registerButtonTapped() {
-        self.delegate?.registerReviewVC()
+        self.delegate?.presentRegisterReviewViewController()
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/Presenter/Home/MyHome/Views/PathTableViewCell.swift
+++ b/Sources/Presenter/Home/MyHome/Views/PathTableViewCell.swift
@@ -12,6 +12,8 @@ import CoreLocation
 protocol ActionSheetDelegate: AnyObject {
     func showPathActionSheet(alert: UIAlertController)
     func showSettingActionSheet(alert: UIAlertController)
+    func moveModifyVC()
+    func registerReviewVC()
 }
 
 enum PathType {
@@ -124,6 +126,7 @@ class PathTableViewCell: UITableViewCell {
             make.top.equalToSuperview().inset(15)
             make.leading.equalToSuperview().inset(70)
             make.height.equalTo(15)
+            make.width.equalTo(150)
         }
         
         comment.snp.makeConstraints { make in

--- a/Sources/Presenter/Home/MyHome/Views/PathTableViewCell.swift
+++ b/Sources/Presenter/Home/MyHome/Views/PathTableViewCell.swift
@@ -12,8 +12,8 @@ import CoreLocation
 protocol ActionSheetDelegate: AnyObject {
     func showPathActionSheet(alert: UIAlertController)
     func showSettingActionSheet(alert: UIAlertController)
-    func moveModifyVC()
-    func registerReviewVC()
+    func presentModifyViewController()
+    func presentRegisterReviewViewController()
 }
 
 enum PathType {
@@ -205,7 +205,7 @@ class PathTableViewCell: UITableViewCell {
             return
         }
         
-        let appStoreURL = URL(string: "http://itunes.apple.com/app/id311867728?mt=8")
+        let appStoreURL = URL(string: "https://tom7930.tistory.com/54")
         guard let appStoreURL = appStoreURL else { return }
         UIApplication.shared.canOpenURL(url) ? UIApplication.shared.open(url) : UIApplication.shared.open(appStoreURL)
     }

--- a/SupportingFiles/ComeIt-Info.plist
+++ b/SupportingFiles/ComeIt-Info.plist
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>nmap</string>
-		<string>kakaokompassauth</string>
-		<string>kakaolink</string>
-	</array>
-	<key>LSApplicationCategoryType</key>
-	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -39,6 +31,14 @@
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>nmap</string>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## 🔍 개요
#155 

## 📝 작업사항
- 코스를 수정하는경우가 총 5가지경우가 있습니다

```swift
enum AddCourseFlowType: Int {
    // 과거에 계획을 안한경우 -> 계획,후기를 등록합니다0
    case addCourse = 0
    
    // 후기등록건드려야함
    // 과거인데 계획을 했을경우 -> 후기만 등록합니다
    // 미래인데 계획을 했을경우 -> 버튼 비활성화되어야함
    case registerReview
    
    // 수정버튼 건드려야함
    // 과거인데 계획이 되어있고 수정을 하는경우 -> 타이틀과 장소를 수정합니다0
    case editCourse
    
    // 미래인데 계획이 안되어있는 경우 -> 버튼 title을 바꿔야합니다0
    case addPlan
    
    // 수정버튼 건드려야함
    // 미래인데 계획이 되어있고 수정을 하는 경우 -> 타이틀하고 장소를 수정합니다0
    case editPlan
    
    // 이전에있던 addCourseFlowType Case
    case plan
    case record
}
```
위와 같은 경우마다 수정flow와 등록flow가 모두 다르기때문에 type으로 coordinator로 넘겨주고
이후에 분기처리로 flow를 user에게 보내주는 방식으로 구현했습니다
