### PR TITLE
🐛 LogHome 탭바 오류, 버튼 인덱스 오류 해결

### DIFF
--- a/Sources/Presenter/Log/LogHome/ViewController/LogHomeViewController.swift
+++ b/Sources/Presenter/Log/LogHome/ViewController/LogHomeViewController.swift
@@ -292,10 +292,19 @@ extension LogHomeViewController {
     
     /// 이전, 이후, 현재 별자리의 제약조건을 추가합니다.
     func setConstellationButtonOption() {
-        previousConstellationButton.isHidden = (currentIndex == 0) ? true : false
-        nextConstellationButton.isHidden = (currentIndex == viewModel.courses.count - 1) ? true : false
         
         let courses = viewModel.courses
+        
+        if courses.isEmpty {
+            previousConstellationButton.isHidden = true
+            currentConstellationButton.isHidden = true
+            nextConstellationButton.isHidden = true
+            return
+        } else {
+            previousConstellationButton.isHidden = (currentIndex == 0) ? true : false
+            nextConstellationButton.isHidden = (currentIndex == viewModel.courses.count - 1) ? true : false
+        }
+        
         let currentConstellationImage = StarMaker.makeStars(places: courses[currentIndex].places)?.resizeImageTo(size: CGSize(width: 22, height: 22))
         
         let previousConstellationImage = StarMaker.makeStars(places: courses[max(currentIndex - 1, 0)].places)?.resizeImageTo(size: CGSize(width: 13, height: 13))

--- a/Sources/Presenter/Log/LogMap/ViewController/LogMapViewController.swift
+++ b/Sources/Presenter/Log/LogMap/ViewController/LogMapViewController.swift
@@ -141,7 +141,7 @@ final class LogMapViewController: BaseViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        
+        navigationController?.tabBarController?.tabBar.isHidden = false
         navigationController?.navigationBar.isHidden = false
     }
 }


### PR DESCRIPTION
## 🔍 개요
+ #165 

## 📝 작업사항
- LogMapView에서 LogHome으로에서의 화면 전환시 Tapbar가 없어지는 오류 전환
- ViewModel의 Course 배열이 빈 배열인 경우 out of index 에러 해결


##  func setConstellationButtonOption()

```swift
  if courses.isEmpty {
            previousConstellationButton.isHidden = true
            currentConstellationButton.isHidden = true
            nextConstellationButton.isHidden = true
            return
}
```
> empty 부터 check를 했었어야 했는데 기초적인 실수를 했습니다.

## 🧐 참고 사항

- 더 좋은 코드는 언제나 환영입니다.