### PR TITLE
✨회원탈퇴/행성나가기 구현 및 연결, homeview 오류해결

### DIFF
--- a/Sources/App/AppCoordinator.swift
+++ b/Sources/App/AppCoordinator.swift
@@ -29,21 +29,21 @@ final class AppCoordinator: Coordinator, IntroCoordinatorDelegate, MainCoordinat
         Task {
             do {
                 let userInformations = try await userService.getUserInformations()
-                if userInformations.planet == nil {
-                    await coordinateToCreatePlanet()
-                } else if userInformations.mate == nil {
-                    guard let planet = userInformations.planet else { return }
-                    await coordinateToWaitingMate(
-                        selectedPlanet: planet.image,
-                        planetName: planet.name,
-                        code: planet.code ?? ""
-                    )
-                    return
-                } else {
+//                if userInformations.planet == nil {
+//                    await coordinateToCreatePlanet()
+//                } else if userInformations.mate == nil {
+//                    guard let planet = userInformations.planet else { return }
+//                    await coordinateToWaitingMate(
+//                        selectedPlanet: planet.image,
+//                        planetName: planet.name,
+//                        code: planet.code ?? ""
+//                    )
+//                    return
+//                } else {
                     await coordinateToMainScene()
-                }
-            } catch {
-                await coordinateToLogincScene()
+//                }
+//            } catch {
+//                await coordinateToLogincScene()
             }
         }
     }

--- a/Sources/App/AppCoordinator.swift
+++ b/Sources/App/AppCoordinator.swift
@@ -29,21 +29,21 @@ final class AppCoordinator: Coordinator, IntroCoordinatorDelegate, MainCoordinat
         Task {
             do {
                 let userInformations = try await userService.getUserInformations()
-//                if userInformations.planet == nil {
-//                    await coordinateToCreatePlanet()
-//                } else if userInformations.mate == nil {
-//                    guard let planet = userInformations.planet else { return }
-//                    await coordinateToWaitingMate(
-//                        selectedPlanet: planet.image,
-//                        planetName: planet.name,
-//                        code: planet.code ?? ""
-//                    )
-//                    return
-//                } else {
+                if userInformations.planet == nil {
+                    await coordinateToCreatePlanet()
+                } else if userInformations.mate == nil {
+                    guard let planet = userInformations.planet else { return }
+                    await coordinateToWaitingMate(
+                        selectedPlanet: planet.image,
+                        planetName: planet.name,
+                        code: planet.code ?? ""
+                    )
+                    return
+                } else {
                     await coordinateToMainScene()
-//                }
-//            } catch {
-//                await coordinateToLogincScene()
+                }
+            } catch {
+                await coordinateToLogincScene()
             }
         }
     }

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         
         self.registerForRemoteNotifications()
-        UserDefaults.standard.set("Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmNTEzNzM4NS1lMzAyLTRlMDUtODZjNi1lYmRkMjBiZWM2YTEiLCJhdXRoIjoiVVNFUiJ9.yHjMEQ0HWs1leBg4sVLW4JBWZr1IitGkpKoNALip_a6IxWbS5CSPujE9g4KodZtfQX_5tR31dau9sBcTGnAjcA", forKey: "accessToken")
+        UserDefaults.standard.set("Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNTE0NTk0ZC1hMDUxLTQ5NTQtYTQ5Yy1hY2Q2YjIzMWJmYzIiLCJhdXRoIjoiVVNFUiJ9.WOhcykDZXoRSCBCkweIxJBy0erYCWva4NmIMB2RunjI22YCeOUr8ozXlROeiS8uVp950Rh7cBjw4PY03tt06vA", forKey: "accessToken")
         Font.registerFonts()
         KakaoSDK.initSDK(appKey: "041c741d45744f54da6ed10e0f946672")
         self.window = UIWindow(frame: UIScreen.main.bounds)

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         
         self.registerForRemoteNotifications()
-        UserDefaults.standard.set("Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNTE0NTk0ZC1hMDUxLTQ5NTQtYTQ5Yy1hY2Q2YjIzMWJmYzIiLCJhdXRoIjoiVVNFUiJ9.WOhcykDZXoRSCBCkweIxJBy0erYCWva4NmIMB2RunjI22YCeOUr8ozXlROeiS8uVp950Rh7cBjw4PY03tt06vA", forKey: "accessToken")
+        UserDefaults.standard.set("Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI3YTk2NTFiZS1kNWIzLTQ5NDUtOTQ3Ny05NTUyMjU5MTIwMTYiLCJhdXRoIjoiVVNFUiJ9.xh5HUu4dRLjkb6nXv8lXVsDjQKpcc2FwnlfPXU5rulcL06rRx4Hnbh53Q69cMUdPsORGg9lM0P1DCTky0reQug", forKey: "accessToken")
         Font.registerFonts()
         KakaoSDK.initSDK(appKey: "041c741d45744f54da6ed10e0f946672")
         self.window = UIWindow(frame: UIScreen.main.bounds)

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         
         self.registerForRemoteNotifications()
-        UserDefaults.standard.set("Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI5N2Q3MmZjNi1jMDY3LTQ0M2EtYWYxNy0wNDc4MWZhZjdiZjQiLCJhdXRoIjoiVVNFUiJ9.8BhkTffQ5jByS8uL0D9RRGpUpahf70t9qZNSnRcfzEHrW4X2uxcaKfgzco39iQW3Puveb4ol2gl1-mLwkXxh8g", forKey: "accessToken")
+        UserDefaults.standard.set("Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmNTEzNzM4NS1lMzAyLTRlMDUtODZjNi1lYmRkMjBiZWM2YTEiLCJhdXRoIjoiVVNFUiJ9.yHjMEQ0HWs1leBg4sVLW4JBWZr1IitGkpKoNALip_a6IxWbS5CSPujE9g4KodZtfQX_5tR31dau9sBcTGnAjcA", forKey: "accessToken")
         Font.registerFonts()
         KakaoSDK.initSDK(appKey: "041c741d45744f54da6ed10e0f946672")
         self.window = UIWindow(frame: UIScreen.main.bounds)

--- a/Sources/DesignSystem/Views/Calendar/DataSource/PresentCalendarDiffableDataSource.swift
+++ b/Sources/DesignSystem/Views/Calendar/DataSource/PresentCalendarDiffableDataSource.swift
@@ -9,8 +9,11 @@
 import UIKit
 
 final class PresentCalendarDiffableDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarSection.Item> {
-
+   
+    var selecteDate: YearMonthDayDate?
+    
     init(collectionView: UICollectionView) {
+        
         super.init(collectionView: collectionView) { collectionView, indexPath, itemIdentifier in
             switch itemIdentifier {
             case .day(let model):

--- a/Sources/DesignSystem/Views/Calendar/Extensions/Date+.swift
+++ b/Sources/DesignSystem/Views/Calendar/Extensions/Date+.swift
@@ -35,6 +35,10 @@ extension Date {
     var monthBefore: Date {
         Calendar.current.date(byAdding: .month, value: -1, to: self)!
     }
+    
+    var month2Before: Date {
+        Calendar.current.date(byAdding: .month, value: -2, to: self)!
+    }
 
     var monthAfter: Date {
         Calendar.current.date(byAdding: .month, value: 1, to: self)!

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -165,13 +165,6 @@ final class HomeViewController: BaseViewController {
                 self.pathTableView.reloadData()
             }
             .store(in: &myCancelBag)
-        
-        viewModel.$selectedDate
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] date in
-                self?.selectedDate = date
-            }
-            .store(in: &myCancelBag)
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -65,52 +65,12 @@ final class HomeViewController: BaseViewController {
         return label
     }()
     
-    lazy var inviteMateButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setTitle("메이트 초대하기", for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 10, weight: .bold)
-        button.layer.borderWidth = 1
-        button.layer.borderColor = .designSystem(.mainYellow)
-        button.setTitleColor(.designSystem(.mainYellow), for: .normal)
-        button.clipsToBounds = true
-        button.layer.cornerRadius = 10
-        button.addTarget(self, action: #selector(inviteButtonTapped), for: .touchUpInside)
-        return button
-    }()
-    
     let nextDateLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.gmarksans(weight: .light, size: ._13)
         label.text = "⭐️ 포항데이트 D-3"
         label.textColor = .white
         return label
-    }()
-    
-    lazy var moreButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.setImage(UIImage(named: "MoreButtonForOpen"), for: .normal)
-        button.addTarget(self, action: #selector(moreButtonTapped), for: .touchUpInside)
-        return button
-    }()
-    
-    lazy var dateTableView: UITableView = {
-        let tableView = UITableView()
-        tableView.register(DateTableViewCell.self, forCellReuseIdentifier: DateTableViewCell.cellId)
-        tableView.rowHeight = 20
-        tableView.isHidden = true
-        tableView.isScrollEnabled = false
-        tableView.backgroundColor = .clear
-        tableView.clipsToBounds = true
-        tableView.layer.cornerRadius = 10
-        tableView.contentInset = UIEdgeInsets(top: 15, left: 0, bottom: 15, right: 0)
-        tableView.separatorStyle = .none
-        tableView.layer.borderColor = UIColor.white.withAlphaComponent(0.5).cgColor
-        tableView.layer.borderWidth = 0.5
-        let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.light)
-        let blurEffectView = UIVisualEffectView(effect: blurEffect)
-        blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        tableView.backgroundView = blurEffectView
-        return tableView
     }()
     
     lazy var calendarView = CalendarView(today: .init(), frame: .init(origin: .zero, size: .init(width: DeviceInfo.screenWidth - 40, height: 0)))
@@ -166,13 +126,16 @@ final class HomeViewController: BaseViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] receivedValue in
                 guard let self = self else { return }
-                if receivedValue?.mate != nil {
-                    print("메이트 있음")
-                    self.setHasMateUI()
-                } else {
-                    print("메이트 없음")
-                    self.setNoMateUI()
-                }
+                guard let mate = receivedValue?.mate else { return }
+                guard let dday = receivedValue?.planet?.dday else { return }
+                self.homeTitle.attributedText = String.makeAtrributedString(
+                    name: mate.name,
+                    appendString: " 님과 함께",
+                    changeAppendStringSize: ._15,
+                    changeAppendStringWieght: .light,
+                    changeAppendStringColor: .white
+                )
+                self.ddayLabel.text = "D+\(dday)"
             }
             .store(in: &myCancelBag)
         
@@ -201,15 +164,6 @@ final class HomeViewController: BaseViewController {
                 self.pathTableView.reloadData()
             }
             .store(in: &myCancelBag)
-    }
-    
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        super.touchesBegan(touches, with: event)
-        if let touch = touches.first, touch.view == self.backgroundView {
-            self.dateInfoIsHidden = false
-            self.moreButton.setImage(UIImage(named: "MoreButtonForOpen"), for: .normal)
-            self.dateTableView.isHidden = true
-        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -241,60 +195,9 @@ final class HomeViewController: BaseViewController {
         setUI()
     }
     
-    private func setNoMateUI() {
-        guard let user = self.viewModel.user else { return }
-        self.homeTitle.attributedText = String.makeAtrributedString(
-            name: user.me.name,
-            appendString: " 님 반갑습니다",
-            changeAppendStringSize: ._15,
-            changeAppendStringWieght: .light,
-            changeAppendStringColor: .white
-        )
-        
-        self.view.addSubviews(self.inviteMateButton)
-        self.inviteMateButton.snp.makeConstraints { make in
-            make.leading.equalTo(self.homeTitle.snp.leading)
-            make.top.equalTo(self.homeTitle.snp.bottom).offset(5)
-            make.width.equalTo(90)
-            make.height.equalTo(25)
-        }
-        
-        self.nextDateLabel.snp.remakeConstraints { make in
-            make.top.equalTo(self.inviteMateButton.snp.bottom).offset(10)
-            make.leading.equalTo(self.homeTitle.snp.leading)
-            make.height.equalTo(15)
-        }
-        
-        self.ddayLabel.isHidden = true
-        self.inviteMateButton.isHidden = false
-    }
-    
-    private func setHasMateUI() {
-        guard let userMate = self.viewModel.user?.mate else { return }
-        guard let dday = self.viewModel.user?.planet?.dday else { return }
-        self.homeTitle.attributedText = String.makeAtrributedString(
-            name: userMate.name,
-            appendString: " 님과 함께",
-            changeAppendStringSize: ._15,
-            changeAppendStringWieght: .light,
-            changeAppendStringColor: .white
-        )
-        
-        self.ddayLabel.isHidden = false
-        self.inviteMateButton.isHidden = true
-        self.ddayLabel.text = "D+\(dday)"
-    }
-    
     @objc
     func alarmButtonTapped() {
         viewModel.pushToAlarmView()
-    }
-    
-    @objc
-    func moreButtonTapped() {
-        dateInfoIsHidden.toggle()
-        dateTableView.isHidden.toggle()
-        moreButton.setImage(dateInfoIsHidden ? UIImage(named: "MoreButtonForClose") : UIImage(named: "MoreButtonForOpen"), for: .normal)
     }
     
     @objc
@@ -316,13 +219,9 @@ extension HomeViewController {
         view.addSubview(alarmButton)
         view.addSubview(ddayLabel)
         view.addSubview(nextDateLabel)
-        view.addSubview(moreButton)
         view.addSubview(pathTableView)
         view.addSubview(calendarView)
-        // MARK: - DateTableView가 맨위에 있어야 Layer가 가장 위쪽으로 적용이 된다
-        view.addSubview(dateTableView)
         view.addSubview(dateCoureRegisterButton)
-        dateTableView.dataSource = self
         pathTableView.delegate = self
         pathTableView.dataSource = self
         calendarView.delegate = self
@@ -354,24 +253,11 @@ extension HomeViewController {
             make.height.equalTo(15)
         }
         
-        moreButton.snp.makeConstraints { make in
-            make.centerY.equalTo(nextDateLabel.snp.centerY)
-            make.leading.equalTo(nextDateLabel.snp.trailing).offset(5)
-            make.size.equalTo(16)
-        }
-        
-        dateTableView.snp.makeConstraints { make in
-            make.leading.equalTo(homeTitle.snp.leading)
-            make.top.equalTo(nextDateLabel.snp.bottom).offset(5)
-            make.width.equalTo(150)
-            make.height.equalTo(viewModel.ddayDateList.count * 20 + 30)
-        }
-        
         calendarView.snp.makeConstraints { make in
             make.top.equalTo(nextDateLabel.snp.bottom).offset(20)
             make.leading.trailing.equalToSuperview().inset(20)
         }
-
+        
         dateCoureRegisterButton.snp.makeConstraints { make in
             make.top.equalTo(calendarView.snp.bottom).offset(10)
             make.leading.trailing.equalToSuperview().inset(20)
@@ -382,42 +268,31 @@ extension HomeViewController {
 
 extension HomeViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let sectionCount = (tableView == dateTableView ? viewModel.ddayDateList.count : viewModel.dateCourse?.courseList.count)
-        guard let sectionCount = sectionCount else { return 0 }
+        guard let sectionCount = viewModel.dateCourse?.courseList.count else { return 0 }
         return sectionCount
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        
-        if tableView == dateTableView {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: DateTableViewCell.cellId, for: indexPath) as? DateTableViewCell else { return UITableViewCell() }
-            cell.selectionStyle = .none
-            cell.dateData = viewModel.ddayDateList[indexPath.row]
-            return cell
-        } else if tableView == pathTableView {
-            
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: PathTableViewCell.cellId, for: indexPath) as? PathTableViewCell else { return UITableViewCell() }
-            cell.delegate = self
-            guard let course = viewModel.dateCourse else { return UITableViewCell() }
-            switch indexPath.row {
-            case 0:
-                cell.lineUpper.isHidden = true
-                // MARK: - 코스가 하나일때 분기처리
-                if course.courseList.count == 1 {
-                    cell.lineLower.isHidden = true
-                }
-            case course.courseList.index(before: course.courseList.endIndex):
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: PathTableViewCell.cellId, for: indexPath) as? PathTableViewCell else { return UITableViewCell() }
+        cell.delegate = self
+        guard let course = viewModel.dateCourse else { return UITableViewCell() }
+        switch indexPath.row {
+        case 0:
+            cell.lineUpper.isHidden = true
+            // MARK: - 코스가 하나일때 분기처리
+            if course.courseList.count == 1 {
                 cell.lineLower.isHidden = true
-            default:
-                cell.lineLower.isHidden = false
-                cell.lineUpper.isHidden = false
             }
-            cell.data = viewModel.dateCourse?.courseList[indexPath.row]
-            cell.backgroundColor = .clear
-            cell.selectionStyle = .none
-            return cell
+        case course.courseList.index(before: course.courseList.endIndex):
+            cell.lineLower.isHidden = true
+        default:
+            cell.lineLower.isHidden = false
+            cell.lineUpper.isHidden = false
         }
-        return UITableViewCell()
+        cell.data = viewModel.dateCourse?.courseList[indexPath.row]
+        cell.backgroundColor = .clear
+        cell.selectionStyle = .none
+        return cell
     }
 }
 
@@ -466,7 +341,7 @@ extension HomeViewController: ActionSheetDelegate {
             viewModel.startAddCourseFlow(type: .registerReview)
         }
     }
-
+    
     func showPathActionSheet(alert: UIAlertController) {
         self.present(alert, animated: true)
     }
@@ -510,7 +385,7 @@ extension HomeViewController: CalendarViewDelegate {
             }
         }
     }
-
+    
     func scrollViewDidEndDecelerating() {
         UIView.animate(withDuration: 0.2, delay: 0) {
             self.view.layoutIfNeeded()
@@ -529,11 +404,11 @@ extension HomeViewController: CalendarViewDelegate {
         default:
             break
         }
-
+        
         self.dateCoureRegisterButton.isHidden = false
         self.pathTableView.isHidden = true
     }
-
+    
     private func getCurrentDateRange() -> [String] {
         let currentDate = Date()
         let beforeDate = Date().month2Before

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -176,8 +176,8 @@ final class HomeViewController: BaseViewController {
             try await viewModel.fetchUserInfo()
             try await viewModel.fetchDateRange(dateRange: currentDateRange)
             if viewModel.dateCalendarList.map({ $0.asDate() }).contains(viewModel.selectedDate) {
-                try await viewModel.fetchSelectedDateCourse(selectedDate: viewModel.selectedDate.toString())
-                self.calendarView.selectDateDirectly(self.selectedDate)
+                try await viewModel.fetchSelectedDateCourse(selectedDate: viewModel.selectedDate.dateToString())
+                self.calendarView.selectDateDirectly(viewModel.selectedDate)
                 self.dateCoureRegisterButton.isHidden = true
             } else {
                 setRegisterButton(viewModel.selectedDate > Date() ? .addPlan : .addCourse)
@@ -386,9 +386,7 @@ extension HomeViewController: CalendarViewDelegate {
     /// - Parameter date: 내가 누른 날짜
     func selectDate(_ date: Date?) {
         guard let date = date else { return }
-        
-        print(date)
-        
+
         Task {
             self.viewModel.selectedDate = date
             // MARK: - 내가 누른 날짜가 처음에 조회한 데이트가 존재하는 날짜에 포함되어있는지를 판단

--- a/Sources/Presenter/Home/MyHome/ViewModel/HomeViewModel.swift
+++ b/Sources/Presenter/Home/MyHome/ViewModel/HomeViewModel.swift
@@ -35,7 +35,7 @@ final class HomeViewModel: BaseViewModel {
     @Published var dateCalendarList: [YearMonthDayDate] = []
     @Published var dateCourse: HomeCourse?
     @Published var places: [Place] = []
-    var selectedDate: Date = Date()
+    @Published var selectedDate: Date = Date()
     
     let ddayDateList = [
         DateDday(title: "인천데이트", dday: 10),
@@ -76,14 +76,6 @@ final class HomeViewModel: BaseViewModel {
             .map { YearMonthDayDate(year: $0.year, month: $0.month, day: $0.day) }
     }
     
-    /// 코스가 존재하는지 존재하지 않는지 여부를 판단하는 함수
-    /// - Parameter selectedDate: 캘린더에서 내가 누른 날짜
-    /// - Returns: 내가누른 날짜가 fetchDateRange에서 받아온 리스트에 포함되어있는지 아닌지를 판단하는 함수
-    func hasCourse(selectedDate: String) -> Bool {
-        guard let selectedDate = selectedDate.toDate() else { return true }
-        return dateCalendarList.map { $0.asDate() }.contains(selectedDate)
-    }
-    
     /// 선택한 날짜의 데이트 코스 정보를 불러오는 함수
     /// - Parameter selectedDate: 캘린더에서 내가 누른 날짜
     func fetchSelectedDateCourse(selectedDate: String) async throws {
@@ -109,22 +101,17 @@ extension HomeViewModel {
         switch type {
         case .addCourse:
             coordinator.startAddCourseFlow(courseRequestDTO: .init(title: "", date: selectedDate.toString(), places: []))
-            print(selectedDate.toString())
         case .registerReview:
             guard let dateCourse = dateCourse else { return }
             coordinator.startRegisterReviewFlow(courseRequestDTO: .init(id: dateCourse.courseId, title: dateCourse.courseTitle, date: dateCourse.courseDate, places: places))
-            print(dateCourse.courseDate)
         case .editCourse:
             guard let dateCourse = dateCourse else { return }
             coordinator.startEditCourseFlow(courseRequestDTO: .init(id: dateCourse.courseId, title: dateCourse.courseTitle, date: dateCourse.courseDate, places: places))
-            print(dateCourse.courseDate)
         case .addPlan:
             coordinator.startAddPlanFlow(courseRequestDTO: .init(title: "", date: selectedDate.toString(), places: []))
-            print(selectedDate.toString())
         case .editPlan:
             guard let dateCourse = dateCourse else { return }
             coordinator.startEditPlanFlow(courseRequestDTO: .init(id: dateCourse.courseId, title: dateCourse.courseTitle, date: dateCourse.courseDate, places: places))
-            print(dateCourse.courseDate)
         }
     }
 }

--- a/Sources/Presenter/Home/MyHome/ViewModel/HomeViewModel.swift
+++ b/Sources/Presenter/Home/MyHome/ViewModel/HomeViewModel.swift
@@ -35,7 +35,7 @@ final class HomeViewModel: BaseViewModel {
     @Published var dateCalendarList: [YearMonthDayDate] = []
     @Published var dateCourse: HomeCourse?
     @Published var places: [Place] = []
-    @Published var selectedDate: Date = Date()
+    @Published var selectedDate: Date = YearMonthDayDate.today.asDate()
     
     let ddayDateList = [
         DateDday(title: "인천데이트", dday: 10),

--- a/Sources/Presenter/Profile/Logout/UserWarning/UserWarningViewController.swift
+++ b/Sources/Presenter/Profile/Logout/UserWarning/UserWarningViewController.swift
@@ -17,6 +17,11 @@ enum OutgoingType {
     case membershipWithdrawal
 }
 
+enum WarningAlarmType {
+    case exitPlanet
+    case withDrawalMembership
+}
+
 final class UserWarningViewController: BaseViewController {
     
     @Published var isAgreed: Bool = false
@@ -165,15 +170,33 @@ final class UserWarningViewController: BaseViewController {
 
         if outgoingType == .exitPlanet {
             Task {
+                makeUserWarningAlarm(.exitPlanet)
                 try await ExitAPIService.exitPlanet()
-                let nextVC = RecoverUserInfoViewController()
-                navigationController?.pushViewController(nextVC, animated: true)
             }
         } else {
             Task {
+                makeUserWarningAlarm(.withDrawalMembership)
                 try await ExitAPIService.membershipWithdrawal()
-                
             }
+        }
+    }
+    
+    func makeUserWarningAlarm(_ alarmType: WarningAlarmType) {
+        switch alarmType {
+        case .exitPlanet:
+            let alert = UIAlertController(title: "행성을 나가시겠습니까", message: "행성을 정말로 나가시겠습니까?", preferredStyle: UIAlertController.Style.alert)
+            let defaultAction = UIAlertAction(title: "네 나가겠습니다", style: UIAlertAction.Style.default)
+            let cancelAction = UIAlertAction(title: "아니요 안나가겠습니다", style: UIAlertAction.Style.cancel)
+            alert.addAction(defaultAction)
+            alert.addAction(cancelAction)
+            self.present(alert, animated: false)
+        case .withDrawalMembership:
+            let alert = UIAlertController(title: "회원을 탈퇴하시겠습니까?", message: "모든정보가 지워집니다", preferredStyle: UIAlertController.Style.alert)
+            let defaultAction = UIAlertAction(title: "네 나가겠습니다", style: UIAlertAction.Style.default)
+            let cancelAction = UIAlertAction(title: "아니요 안나가겠습니다", style: UIAlertAction.Style.cancel)
+            alert.addAction(defaultAction)
+            alert.addAction(cancelAction)
+            self.present(alert, animated: false)
         }
     }
 }

--- a/Sources/Presenter/Profile/Profile/ProfileViewController.swift
+++ b/Sources/Presenter/Profile/Profile/ProfileViewController.swift
@@ -173,8 +173,9 @@ extension ProfileViewController {
         let editPlanetNameAction = UIAlertAction(title: "행성 이름 변경", style: .default) { [weak self] action in
             self?.viewModel.coordinateToEditPlanet()
         }
-        let exitPlanetAction = UIAlertAction(title: "행성 나가기", style: .default) { action in
+        let exitPlanetAction = UIAlertAction(title: "행성 나가기", style: .default) { [weak self] action in
             // TODO: logic 추가
+            self?.viewModel.coordinateToExitPlanet()
         }
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         

--- a/Sources/Presenter/Profile/Profile/ProfileViewModel.swift
+++ b/Sources/Presenter/Profile/Profile/ProfileViewModel.swift
@@ -14,6 +14,7 @@ protocol ProfileCoordinatorLogic: Coordinator {
     func pushToEditDayView()
     func coordinateToEditProfile()
     func coordinateToEditPlanet(date: String, planetName: String, planetImageName: String)
+    func coordinateToExitPlanet(type: OutgoingType)
 }
 
 final class ProfileViewModel: BaseViewModel {
@@ -49,6 +50,10 @@ final class ProfileViewModel: BaseViewModel {
 
     func coordinateToEditPlanet() {
         coordinator.coordinateToEditPlanet(date: date, planetName: planetName, planetImageName: planetImageName)
+    }
+    
+    func coordinateToExitPlanet() {
+        coordinator.coordinateToExitPlanet(type: .exitPlanet)
     }
 }
 

--- a/Sources/Presenter/Profile/ProfileCoordinator.swift
+++ b/Sources/Presenter/Profile/ProfileCoordinator.swift
@@ -74,8 +74,15 @@ extension ProfileCoordinator: ProfileCoordinatorLogic, Popable, EditProfileCoord
         editPlanet.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(editPlanet, animated: true)
     }
+    
     func coordinateToDeRegisterScene() {
-        // MARK: 이동
+        let withdrwalViewController = UserWarningViewController(outgoingType: .membershipWithdrawal)
+        self.navigationController?.pushViewController(withdrwalViewController, animated: true)
+    }
+    
+    func coordinateToExitPlanet(type: OutgoingType) {
+        let exitPlanetViewController = UserWarningViewController(outgoingType: .exitPlanet)
+        self.navigationController?.pushViewController(exitPlanetViewController, animated: true)
     }
 }
 


### PR DESCRIPTION
## 🔍 개요
#176 

## 📝 작업사항
- 캘린더에 오류가 많았습니다
- 1. 캘린더를 좌우로 움직일때 오른쪽으로 움직였다가 돌아오면 경로가 제대로 보이지 않는버그
- 2. 오늘 데이트가 있는데 앱에서 들어가면 경로테이블이 안보이고 등록 버튼이 보이는 버그
- 3. 왼쪽오른쪽으로 넘길때 테이블뷰가 사라졋다가 바로 나타나는 버그
- 4. 3과 마찬가지로 버튼이 왔다갔다하는버그
- 5. 오늘 데이트가 없는데 등록버튼에 라벨이 없어지는 버그
- 6. 가끔가다 몇가지 코스가 조회되지 않는오류(포딩쪽에서 해결)
- 7. 코스를 생성하고 다시 view로 돌아왔을떄 click이 해제되어있는 경우(우디쪽에서 해결)
- 8. 다음달이나 이전달로 넘어갔는데(1일로 초기화) 코스테이블이 안보이고 등록버튼이 보이는 버그
- 9. 코스를 등록한 후 다시 view로 돌아왔는데 데이터가 업데이트안되서 버튼만보이는 버그(버튼을 한번더 눌러야 테이블이 보이는 버그)
- 10. 테이블뷰와 버튼이 동시에 보이거나 동시에 보이지 않는 버그

회원탈퇴/행성나가기 프로필에서 구현해놨고요
버튼을눌렀을때 아무런 인터렉션이 없으면 너무 이상해서 경고알림도 추가해놨습니다

