### PR TITLE
💄프로필뷰 수정 및 백그라운드블러 적용

### DIFF
--- a/Sources/DesignSystem/Views/Calendar/CalendarView.swift
+++ b/Sources/DesignSystem/Views/Calendar/CalendarView.swift
@@ -20,7 +20,14 @@ final class CalendarView: BaseView {
   
     static let inset: CGFloat = 0
     static let cellHeight: CGFloat = (DeviceInfo.screenWidth - 80 - 1 - CalendarView.inset * 6) / 7
-
+    
+    lazy var blurEffectView: UIVisualEffectView = {
+        let blurEffectView = UIVisualEffectView.myBlurEffectView
+        blurEffectView.clipsToBounds = true
+        blurEffectView.layer.cornerRadius = 15
+        return blurEffectView
+    }()
+    
     // MARK: - Properties
 
     weak var delegate: CalendarViewDelegate?
@@ -159,7 +166,7 @@ final class CalendarView: BaseView {
         self.layer.cornerRadius = 15
         self.layer.borderColor = UIColor.white.withAlphaComponent(0.5).cgColor
         self.layer.borderWidth = 0.3
-        self.backgroundColor = .designSystem(.calendarRed)?.withAlphaComponent(0.2)
+        self.backgroundColor = .designSystem(.calendarRed)?.withAlphaComponent(0.5)
 
         monthView.delegate = self
         scrollView.delegate = self
@@ -173,6 +180,10 @@ final class CalendarView: BaseView {
     }
 
     override func setLayout() {
+        addSubview(blurEffectView)
+        blurEffectView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
         addSubview(monthView)
         
         addSubview(weekdayView)

--- a/Sources/DesignSystem/Views/Calendar/CalendarView.swift
+++ b/Sources/DesignSystem/Views/Calendar/CalendarView.swift
@@ -22,7 +22,7 @@ final class CalendarView: BaseView {
     static let cellHeight: CGFloat = (DeviceInfo.screenWidth - 80 - 1 - CalendarView.inset * 6) / 7
     
     lazy var blurEffectView: UIVisualEffectView = {
-        let blurEffectView = UIVisualEffectView.myBlurEffectView
+        let blurEffectView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.dark))
         blurEffectView.clipsToBounds = true
         blurEffectView.layer.cornerRadius = 15
         return blurEffectView

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -40,8 +40,6 @@ final class HomeViewController: BaseViewController {
         return label
     }()
     
-    let testView = UIView()
-    
     let nextDateLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.gmarksans(weight: .light, size: ._13)
@@ -91,10 +89,7 @@ final class HomeViewController: BaseViewController {
         tableView.backgroundColor = .designSystem(.mainYellow)?.withAlphaComponent(0.5)
         tableView.layer.borderColor = UIColor.white.withAlphaComponent(0.5).cgColor
         tableView.layer.borderWidth = 0.3
-        let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
-        let blurEffectView = UIVisualEffectView(effect: blurEffect)
-        blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        tableView.backgroundView = blurEffectView
+        tableView.backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.dark))
         return tableView
     }()
     
@@ -230,11 +225,6 @@ final class HomeViewController: BaseViewController {
 // MARK: - UI
 extension HomeViewController {
     func setAttributes() {
-        view.addSubview(testView)
-//        testView.backgroundColor = .red
-        testView.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(60)
-        }
         view.addSubview(homeTitle)
         view.addSubview(alarmButton)
         view.addSubview(ddayLabel)
@@ -492,12 +482,4 @@ extension HomeViewController: AlarmResponseDelegate {
     func fetchAlarm() {
         viewWillAppear(true)
     }
-}
-
-extension UIBlurEffect {
-    static let myBlurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
-}
-
-extension UIVisualEffectView {
-    static let myBlurEffectView = UIVisualEffectView(effect: UIBlurEffect.myBlurEffect)
 }

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -20,9 +20,6 @@ final class HomeViewController: BaseViewController {
     var dateInfoIsHidden: Bool = false
     var selectedDate: Date = YearMonthDayDate.today.asDate()
     
-    let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.systemUltraThinMaterial)
-    lazy var blurEffectView = UIVisualEffectView(effect: self.blurEffect)
-    
     let homeTitle: UILabel = {
         let label = UILabel()
         label.font = UIFont.gmarksans(weight: .bold, size: ._20)
@@ -43,6 +40,8 @@ final class HomeViewController: BaseViewController {
         return label
     }()
     
+    let testView = UIView()
+    
     let nextDateLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.gmarksans(weight: .light, size: ._13)
@@ -50,8 +49,7 @@ final class HomeViewController: BaseViewController {
         label.textColor = .white
         return label
     }()
-    
-    
+        
     let homeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.showsVerticalScrollIndicator = false
@@ -90,10 +88,10 @@ final class HomeViewController: BaseViewController {
         tableView.clipsToBounds = true
         tableView.layer.cornerRadius = 15
         tableView.contentInset = UIEdgeInsets(top: -20, left: 0, bottom: 0, right: 0)
-        tableView.backgroundColor = .designSystem(.mainYellow)?.withAlphaComponent(0.2)
+        tableView.backgroundColor = .designSystem(.mainYellow)?.withAlphaComponent(0.5)
         tableView.layer.borderColor = UIColor.white.withAlphaComponent(0.5).cgColor
         tableView.layer.borderWidth = 0.3
-        let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.systemUltraThinMaterial)
+        let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
         let blurEffectView = UIVisualEffectView(effect: blurEffect)
         blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         tableView.backgroundView = blurEffectView
@@ -232,6 +230,11 @@ final class HomeViewController: BaseViewController {
 // MARK: - UI
 extension HomeViewController {
     func setAttributes() {
+        view.addSubview(testView)
+//        testView.backgroundColor = .red
+        testView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(60)
+        }
         view.addSubview(homeTitle)
         view.addSubview(alarmButton)
         view.addSubview(ddayLabel)
@@ -241,7 +244,6 @@ extension HomeViewController {
         
         self.contentView.addSubview(pathTableView)
         self.contentView.addSubview(calendarView)
-        calendarView.backgroundView = blurEffectView
         self.contentView.addSubview(dateCoureRegisterButton)
         pathTableView.delegate = self
         pathTableView.dataSource = self
@@ -490,4 +492,12 @@ extension HomeViewController: AlarmResponseDelegate {
     func fetchAlarm() {
         viewWillAppear(true)
     }
+}
+
+extension UIBlurEffect {
+    static let myBlurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
+}
+
+extension UIVisualEffectView {
+    static let myBlurEffectView = UIVisualEffectView(effect: UIBlurEffect.myBlurEffect)
 }

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -20,6 +20,9 @@ final class HomeViewController: BaseViewController {
     var dateInfoIsHidden: Bool = false
     var selectedDate: Date = YearMonthDayDate.today.asDate()
     
+    let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.systemUltraThinMaterial)
+    lazy var blurEffectView = UIVisualEffectView(effect: self.blurEffect)
+    
     let homeTitle: UILabel = {
         let label = UILabel()
         label.font = UIFont.gmarksans(weight: .bold, size: ._20)
@@ -47,6 +50,7 @@ final class HomeViewController: BaseViewController {
         label.textColor = .white
         return label
     }()
+    
     
     let homeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -89,6 +93,10 @@ final class HomeViewController: BaseViewController {
         tableView.backgroundColor = .designSystem(.mainYellow)?.withAlphaComponent(0.2)
         tableView.layer.borderColor = UIColor.white.withAlphaComponent(0.5).cgColor
         tableView.layer.borderWidth = 0.3
+        let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.systemUltraThinMaterial)
+        let blurEffectView = UIVisualEffectView(effect: blurEffect)
+        blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        tableView.backgroundView = blurEffectView
         return tableView
     }()
     
@@ -233,6 +241,7 @@ extension HomeViewController {
         
         self.contentView.addSubview(pathTableView)
         self.contentView.addSubview(calendarView)
+        calendarView.backgroundView = blurEffectView
         self.contentView.addSubview(dateCoureRegisterButton)
         pathTableView.delegate = self
         pathTableView.dataSource = self

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -40,6 +40,7 @@ final class HomeViewController: BaseViewController {
         return label
     }()
     
+    // MARK: - 추후 api연결
     let nextDateLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.gmarksans(weight: .light, size: ._13)

--- a/Sources/Presenter/Profile/EditProfile/EditProfileViewController.swift
+++ b/Sources/Presenter/Profile/EditProfile/EditProfileViewController.swift
@@ -43,6 +43,7 @@ final class EditProfileViewController: BaseViewController {
     lazy var nicknameChangeButton = UIButton(type: .system)
     lazy var logoutButton = UIButton(type: .system)
     lazy var deregisterButton = UIButton(type: .system)
+    lazy var seperatedLine = UIView()
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -109,6 +110,7 @@ extension EditProfileViewController {
         emailLabel.font = .designSystem(weight: .regular, size: ._15)
         emailSubtitleLabel.font = .designSystem(weight: .regular, size: ._13)
         emailSubtitleLabel.textColor = .designSystem(.grayC5C5C5)
+        seperatedLine.backgroundColor = .designSystem(.grayC5C5C5)
         lineView1.backgroundColor = .designSystem(.gray818181)?.withAlphaComponent(0.5)
 
         passwordSubTitleLabel.text = "비밀번호"
@@ -158,6 +160,7 @@ extension EditProfileViewController {
         view.addSubview(stackView)
         view.addSubview(logoutButton)
         view.addSubview(deregisterButton)
+        view.addSubview(seperatedLine)
         stackView.addArrangedSubview(containerView1)
         stackView.addArrangedSubview(containerView2)
         stackView.addArrangedSubview(containerView3)
@@ -246,6 +249,13 @@ extension EditProfileViewController {
         deregisterButton.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(20)
             make.top.equalTo(stackView.snp.bottom).offset(20)
+        }
+        
+        seperatedLine.snp.makeConstraints { make in
+            make.top.equalTo(deregisterButton.snp.top).offset(6)
+            make.bottom.equalTo(deregisterButton.snp.bottom).offset(-6)
+            make.width.equalTo(1)
+            make.trailing.equalTo(deregisterButton.snp.leading).offset(-10)
         }
         logoutButton.snp.makeConstraints { make in
             make.trailing.equalTo(deregisterButton.snp.leading).offset(-20)


### PR DESCRIPTION
## 🔍 개요
#227 

## 📝 작업사항
- 프로필뷰에 로그아웃/회원탈퇴 사이에 세로줄을 그었습니다
- homeviewController에 백그라운드 블러를 처리했는데 피그마와 같은 값으로 처리하면 이상해서 디자이너와 상의가 필요할거같습니다


## 📸 스크린샷 또는 영상
<p>
<img width="250" alt="스크린샷 2022-11-26 오후 6 23 04" src="https://user-images.githubusercontent.com/99013115/204081744-8f33be12-e292-45cc-a42a-a4825d80b500.png">
<img width="250" alt="스크린샷 2022-11-26 오후 5 51 13" src="https://user-images.githubusercontent.com/99013115/204080682-64bb761f-74e3-4a75-9beb-88aacce50a79.png">
<img width="250" alt="스크린샷 2022-11-26 오후 5 50 38" src="https://user-images.githubusercontent.com/99013115/204080679-316f9972-a84c-4428-8840-7f9ad480c321.png">
</p>



## 🧐 참고 사항
tableview같은 경우는 backgroundView라는 set 메서드가 있어서 단순하게 blurEffectview를 넣어줄수있었는데
collectionView나 button은 따로 넣어야할거같습니다

## 📄 Reference
[]()
