### PR TITLE
♻️홈화면 코스등록 플로우(오늘부분) 분기처리 수정 및 티켓, 디데이수정 백그라운드 블러 적용

### DIFF
--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -19,6 +19,13 @@ final class HomeViewController: BaseViewController {
     let viewModel: HomeViewModel
     var dateInfoIsHidden: Bool = false
     var selectedDate: Date = YearMonthDayDate.today.asDate()
+    var currentDate: Date = Date()
+    
+    func changeDateFormat(input: Date) -> Date {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd 15:00:00"
+        return dateFormatter.date(from: dateFormatter.string(from: input))!
+    }
     
     let homeTitle: UILabel = {
         let label = UILabel()
@@ -201,7 +208,9 @@ final class HomeViewController: BaseViewController {
                 self.calendarView.selectDateDirectly(viewModel.selectedDate)
                 self.dateCoureRegisterButton.isHidden = true
             } else {
-                setRegisterButton(viewModel.selectedDate > Date() ? .addPlan : .addCourse)
+                print(viewModel.selectedDate)
+                print(changeDateFormat(input: currentDate))
+                setRegisterButton(viewModel.selectedDate >= changeDateFormat(input: currentDate) ? .addPlan : .addCourse)
             }
         }
     }
@@ -436,7 +445,7 @@ extension HomeViewController: CalendarViewDelegate {
                 try await viewModel.fetchSelectedDateCourse(selectedDate: date.dateToString())
                 self.dateCoureRegisterButton.isHidden = true
             } else {
-                setRegisterButton(date > Date() ? .addPlan : .addCourse)
+                setRegisterButton(date >= changeDateFormat(input: currentDate) ? .addPlan : .addCourse)
                 self.contentView.snp.remakeConstraints { make in
                     make.top.equalToSuperview()
                     make.width.equalToSuperview()

--- a/Sources/Presenter/Log/LogTicket/View/LogTicketEmptyView.swift
+++ b/Sources/Presenter/Log/LogTicket/View/LogTicketEmptyView.swift
@@ -14,9 +14,16 @@ class LogTicketEmptyView: UIView {
     
     var rootViewState = RootViewState.LogHome {
         didSet {
-            setBlur()
+//            setBlur()
         }
     }
+    
+    lazy var blurEffectView: UIVisualEffectView = {
+        let blurEffectView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.systemUltraThinMaterialDark))
+        blurEffectView.clipsToBounds = true
+        blurEffectView.layer.cornerRadius = 15
+        return blurEffectView
+    }()
     
     lazy var flopButton: UIButton = {
         let button = UIButton()
@@ -69,8 +76,14 @@ extension LogTicketEmptyView {
             flopButton,
             heartImageView,
             logTicketEmptyViewLabel,
-            addCourseButton
+            addCourseButton,
+            blurEffectView
         )
+        
+        self.sendSubviewToBack(blurEffectView)
+        blurEffectView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
         
         heartImageView.snp.makeConstraints { make in
             make.width.equalTo(DeviceInfo.screenWidth * 100 / 390)
@@ -102,7 +115,8 @@ extension LogTicketEmptyView {
     // MARK: Ticket Drawing
     private func drawTicket() {
         layer.cornerRadius = 18
-        backgroundColor = .clear
+        // MARK: - 배경화면 분기처리
+        backgroundColor = .designSystem(.pinkEB97D9)?.withAlphaComponent(0.4)
         let radious = DeviceInfo.screenWidth * 0.1282051282 / 2
         let ticketShapeLayer = CAShapeLayer()
         ticketShapeLayer.frame = self.bounds

--- a/Sources/Presenter/Log/LogTicket/View/LogTicketView.swift
+++ b/Sources/Presenter/Log/LogTicket/View/LogTicketView.swift
@@ -12,7 +12,7 @@ class LogTicketView: UIView {
     
     var rootViewState = RootViewState.LogHome {
         didSet {
-            setBlur()
+//            setBlur()
         }
     }
     
@@ -22,6 +22,19 @@ class LogTicketView: UIView {
             setPageControl()
         }
     }
+    
+    var testView: UIView = {
+        let v = UIView()
+        v.backgroundColor = .red
+        return v
+    }()
+    
+    lazy var blurEffectView: UIVisualEffectView = {
+        let blurEffectView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.systemUltraThinMaterialDark))
+        blurEffectView.clipsToBounds = true
+        blurEffectView.layer.cornerRadius = 15
+        return blurEffectView
+    }()
     
     var courseNameLabel: UILabel = {
         let label = UILabel()
@@ -78,6 +91,12 @@ class LogTicketView: UIView {
     // MARK: Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
+
+//        self.addSubview(testView)
+//        testView.snp.makeConstraints { make in
+//            make.edges.equalToSuperview()
+//        }
+
         self.addSubviews(
             courseNameLabel,
             ImageScrollView,
@@ -93,6 +112,11 @@ class LogTicketView: UIView {
             flopButton
         )
         setLayouts()
+        self.addSubview(blurEffectView)
+        self.sendSubviewToBack(blurEffectView)
+        blurEffectView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
         
     }
     
@@ -212,7 +236,8 @@ extension LogTicketView {
     // MARK: Ticket Drawing
     private func drawTicket() {
         layer.cornerRadius = 18
-        backgroundColor = .clear
+        // MARK: - 여기서 티켓뷰 백그라운드 색깔 분기처리
+        backgroundColor = .designSystem(.pinkEB97D9)?.withAlphaComponent(0.4)
         let radious = DeviceInfo.screenWidth * 0.1282051282 / 2
         let ticketShapeLayer = CAShapeLayer()
         ticketShapeLayer.frame = self.bounds
@@ -265,19 +290,26 @@ extension LogTicketView {
     
     // MARK: Blur Effect 추가
     private func setBlur() {
-        let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.regular)
+        let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.systemUltraThinMaterialDark)
         let outerVisualEffectView = UIVisualEffectView(effect: blurEffect)
+        
+        lazy var blurEffectView: UIVisualEffectView = {
+            let blurEffectView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.dark))
+            blurEffectView.clipsToBounds = true
+            blurEffectView.layer.cornerRadius = 15
+            return blurEffectView
+        }()
         
         switch rootViewState {
         case .LogHome:
-            outerVisualEffectView.layer.backgroundColor = UIColor.designSystem(.pinkF09BA1)?.withAlphaComponent(0.5).cgColor
+            blurEffectView.layer.backgroundColor = UIColor.designSystem(.pinkF09BA1)?.withAlphaComponent(0.5).cgColor
         case .LogMap:
-            outerVisualEffectView.layer.backgroundColor = UIColor.designSystem(.black)?.withAlphaComponent(0.75).cgColor
+            blurEffectView.layer.backgroundColor = UIColor.designSystem(.black)?.withAlphaComponent(0.75).cgColor
         }
         
-        outerVisualEffectView.layer.opacity = 0.5
-        outerVisualEffectView.frame = CGRect(x: 0, y: 0, width: DeviceInfo.screenWidth, height: DeviceInfo.screenHeight)
-        self.addSubview(outerVisualEffectView)
-        self.sendSubviewToBack(outerVisualEffectView)
+        blurEffectView.layer.opacity = 0.5
+        blurEffectView.frame = CGRect(x: 0, y: 0, width: DeviceInfo.screenWidth, height: DeviceInfo.screenHeight)
+        self.addSubview(blurEffectView)
+
     }
 }

--- a/Sources/Presenter/Profile/Profile/View/EditDateView.swift
+++ b/Sources/Presenter/Profile/Profile/View/EditDateView.swift
@@ -14,15 +14,13 @@ import SnapKit
 final class EditDateView: UIView {
     var height: CGFloat = 500
     
-    private let blurBackgroundView: UIView = {
-        let blurEffect = UIBlurEffect(style: .regular)
-        let view = UIVisualEffectView(effect: blurEffect)
-        view.layer.cornerRadius = 15
-        view.layer.masksToBounds = true
-        view.layer.backgroundColor = UIColor.designSystem(.pinkF09BA1)?.withAlphaComponent(0.8).cgColor
-        view.layer.opacity = 0.8
-        return view
+    lazy var blurEffectView: UIVisualEffectView = {
+        let blurEffectView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.systemUltraThinMaterialDark))
+        blurEffectView.clipsToBounds = true
+        blurEffectView.layer.cornerRadius = 15
+        return blurEffectView
     }()
+    
     lazy var dismissButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "xmark"), for: .normal)
@@ -70,7 +68,7 @@ final class EditDateView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+        self.backgroundColor = .designSystem(.pinkEB97D9)?.withAlphaComponent(0.3)
         setUI()
     }
     
@@ -84,7 +82,7 @@ extension EditDateView {
     private func setUI() {
         self.layer.cornerRadius = 15
         self.addSubviews(
-            blurBackgroundView,
+            blurEffectView,
             dismissButton,
             imageView,
             viewLabel,
@@ -92,7 +90,8 @@ extension EditDateView {
             doneButton
         )
         
-        blurBackgroundView.snp.makeConstraints { make in
+        self.sendSubviewToBack(blurEffectView)
+        blurEffectView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
         


### PR DESCRIPTION
## 📝 작업사항
- homeviewcontroller에서 오늘날짜에 coordinator분기처리를 기획적으로 수정해야할 부분이있어서 수정했습니다
- 티켓뷰에 backgroundblur를 적용헀습니다
- 디데이수정에서 backgroundblur를 적용했습니다


## 📸 스크린샷 또는 영상

<p>
<img width="300" alt="스크린샷 2022-12-05 오후 3 43 40" src="https://user-images.githubusercontent.com/99013115/205566621-eed94f34-1e84-4296-a2bc-66dff141049e.png">
<img width="250" alt="스크린샷 2022-12-05 오후 3 43 59" src="https://user-images.githubusercontent.com/99013115/205566665-785ff4de-97df-4d07-949c-6386256e75b6.png">
</p>

