### PR TITLE
♻️Youth 1차 QA수정

### DIFF
--- a/Sources/DesignSystem/Views/Calendar/CalendarView.swift
+++ b/Sources/DesignSystem/Views/Calendar/CalendarView.swift
@@ -91,9 +91,10 @@ final class CalendarView: BaseView {
             if model.date == YearMonthDayDate.today {
                 cell.isToday()
                 collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .top)
-            } else if model.date == self.selectedDate {
-                collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .top)
             }
+//            else if model.date == self.selectedDate {
+//                collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .top)
+//            }
 
             return cell
         }

--- a/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
+++ b/Sources/Presenter/Home/MyHome/ViewController/HomeViewController.swift
@@ -46,15 +46,6 @@ final class HomeViewController: BaseViewController {
         label.textColor = .white
         return label
     }()
-    
-    // MARK: - 추후 api연결
-    let nextDateLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.gmarksans(weight: .light, size: ._13)
-        label.text = "        "
-        label.textColor = .white
-        return label
-    }()
         
     let homeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -208,8 +199,6 @@ final class HomeViewController: BaseViewController {
                 self.calendarView.selectDateDirectly(viewModel.selectedDate)
                 self.dateCoureRegisterButton.isHidden = true
             } else {
-                print(viewModel.selectedDate)
-                print(changeDateFormat(input: currentDate))
                 setRegisterButton(viewModel.selectedDate >= changeDateFormat(input: currentDate) ? .addPlan : .addCourse)
             }
         }
@@ -238,7 +227,6 @@ extension HomeViewController {
         view.addSubview(homeTitle)
         view.addSubview(alarmButton)
         view.addSubview(ddayLabel)
-        view.addSubview(nextDateLabel)
         view.addSubview(homeScrollView)
         homeScrollView.addSubview(contentView)
         
@@ -249,7 +237,6 @@ extension HomeViewController {
         pathTableView.dataSource = self
         calendarView.delegate = self
         viewModel.delegate = self
-        
     }
     
     func setUI() {
@@ -271,14 +258,8 @@ extension HomeViewController {
             make.leading.equalTo(homeTitle.snp.leading)
         }
         
-        nextDateLabel.snp.makeConstraints { make in
-            make.top.equalTo(ddayLabel.snp.bottom).offset(10)
-            make.leading.equalTo(homeTitle.snp.leading)
-            make.height.equalTo(15)
-        }
-        
         homeScrollView.snp.makeConstraints { make in
-            make.top.equalTo(nextDateLabel.snp.bottom).offset(10)
+            make.top.equalTo(ddayLabel.snp.bottom).offset(10)
             make.leading.trailing.equalToSuperview()
             make.width.equalToSuperview()
             make.bottom.equalToSuperview()

--- a/Sources/Presenter/Profile/Logout/UserWarning/UserWarningViewController.swift
+++ b/Sources/Presenter/Profile/Logout/UserWarning/UserWarningViewController.swift
@@ -82,7 +82,7 @@ final class UserWarningViewController: BaseViewController {
         let label = UILabel()
         label.font = .designSystem(weight: .regular, size: ._13)
         label.textColor = .designSystem(.white)
-        label.numberOfLines = 2
+        label.numberOfLines = 0
         label.textAlignment = .left
         return label
     }()
@@ -223,7 +223,7 @@ extension UserWarningViewController {
         let membershipWithdrawalLabels = ["나와 메이트 둘 중 한명이라도 회원탈퇴를 하게 되면, 행성이 바로 삭제됩니다.", "행성에 기록된 모든 기록들이 전부 삭제됩니다.", "행성에 기록된 자료는 복구가 불가능합니다."]
         
         nextButton.setTitle(outgoingType == .exitPlanet ? "행성나가기" : "회원탈퇴", for: .normal)
-        summaryLabel.text = outgoingType == .exitPlanet ? "⭐행성이 없으면 앱의 모든기능을 사용할 수 없어요!\n⭐복구기간이 지나면 기록된 내용들이 사라져요!" :
+        summaryLabel.text = outgoingType == .exitPlanet ? "⭐행성이 없으면 앱의 기능을 사용할 수 없어요!\n⭐복구기간이 지나면 기록된 내용들이 사라져요!" :
         "⭐회원탈퇴 시 행성이 사라져요!\n⭐행성에 기록된 모든 정보가 삭제 돼요!"
         summaryLabel.setLineSpacing(spacing: 10)
         warningPhraseLabel.attributedText = bulletPointList(strings: outgoingType == .exitPlanet ? exitPlanetLabels : membershipWithdrawalLabels)
@@ -281,14 +281,14 @@ extension UserWarningViewController {
         
         subTitleLable.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(98)
-            make.leading.trailing.equalToSuperview().inset(90)
+            make.leading.trailing.equalToSuperview()
             make.height.equalTo(18)
         }
         
         summaryPhraseView.snp.makeConstraints { make in
             make.top.equalTo(subTitleLable.snp.bottom).offset(30)
             make.leading.trailing.equalToSuperview().inset(20)
-            make.height.equalTo(72)
+            make.height.equalTo(80)
         }
         
         summaryLabel.snp.makeConstraints { make in


### PR DESCRIPTION
## 🔍 개요
#249 

## 📝 작업사항
- 아이폰mini 레이아웃 깨지는 부분 수정
- 캘린더뷰 날짜가 두번으로 중복 선택되는 부분 수정
- 데이트 dday라벨 삭제 및 ui 빈부분 제거
