### PR TITLE
🐛 LogTicket dismiss button bug 해결

### DIFF
--- a/Sources/Presenter/Log/LogTicket/View/LogTicketEmptyView.swift
+++ b/Sources/Presenter/Log/LogTicket/View/LogTicketEmptyView.swift
@@ -12,17 +12,23 @@ import SnapKit
 
 class LogTicketEmptyView: UIView {
     
-    var rootViewState = RootViewState.LogHome {
-        didSet {
-//            setBlur()
-        }
-    }
+    var rootViewState = RootViewState.LogHome
+    
+    private let viewModel: LogTicketViewModel
     
     lazy var blurEffectView: UIVisualEffectView = {
         let blurEffectView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.systemUltraThinMaterialDark))
         blurEffectView.clipsToBounds = true
         blurEffectView.layer.cornerRadius = 15
         return blurEffectView
+    }()
+    
+    private let dismissButton: UIButton = {
+        let button = UIButton()
+        let configure = UIImage.SymbolConfiguration(pointSize: 22, weight: .bold, scale: .default)
+        button.setImage(UIImage(systemName: "xmark", withConfiguration: configure), for: .normal)
+        button.tintColor = .designSystem(.white)
+        return button
     }()
     
     lazy var flopButton: UIButton = {
@@ -55,9 +61,11 @@ class LogTicketEmptyView: UIView {
     }()
     
     // MARK: Initializer
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(viewModel: LogTicketViewModel) {
+        self.viewModel = viewModel
+        super.init(frame: .zero)
         setLayouts()
+        setButtonTarget()
     }
     
     required init?(coder: NSCoder) {
@@ -77,7 +85,8 @@ extension LogTicketEmptyView {
             heartImageView,
             logTicketEmptyViewLabel,
             addCourseButton,
-            blurEffectView
+            blurEffectView,
+            dismissButton
         )
         
         self.sendSubviewToBack(blurEffectView)
@@ -109,6 +118,13 @@ extension LogTicketEmptyView {
             make.bottom.equalToSuperview().inset(DeviceInfo.screenHeight * 20 / 844)
             make.width.equalTo(DeviceInfo.screenWidth * 310 / 390)
             make.height.equalTo(DeviceInfo.screenHeight * 58 / 844)
+        }
+        
+        dismissButton.snp.makeConstraints { make in
+            make.right.equalToSuperview().inset(DeviceInfo.screenWidth * 20 / 390)
+            make.top.equalToSuperview().inset(DeviceInfo.screenHeight * 20 / 844)
+            make.width.equalTo(DeviceInfo.screenWidth * 22 / 390)
+            make.height.equalTo(DeviceInfo.screenHeight * 24 / 844)
         }
     }
     
@@ -188,5 +204,14 @@ extension LogTicketEmptyView {
         outerVisualEffectView.frame = CGRect(x: 0, y: 0, width: DeviceInfo.screenWidth, height: DeviceInfo.screenHeight)
         self.addSubview(outerVisualEffectView)
         self.sendSubviewToBack(outerVisualEffectView)
+    }
+    
+    private func setButtonTarget() {
+        dismissButton.addTarget(self, action: #selector(tapDismissButton), for: .touchUpInside)
+    }
+    
+    @objc
+    func tapDismissButton() {
+        viewModel.tapDismissButton()
     }
 }

--- a/Sources/Presenter/Log/LogTicket/View/LogTicketView.swift
+++ b/Sources/Presenter/Log/LogTicket/View/LogTicketView.swift
@@ -16,12 +16,7 @@ class LogTicketView: UIView {
     
     private let viewModel: LogTicketViewModel
     
-    var imageUrl: [String] = [] {
-        didSet {
-            setCollectionView()
-            setPageControl()
-        }
-    }
+    var imageUrl: [String] = []
     
     lazy var blurEffectView: UIVisualEffectView = {
         let blurEffectView = UIVisualEffectView(
@@ -112,8 +107,9 @@ class LogTicketView: UIView {
     }()
     
     // MARK: Initializer
-    init(viewModel: LogTicketViewModel) {
+    init(viewModel: LogTicketViewModel, imageUrl: [String]) {
         self.viewModel = viewModel
+        self.imageUrl = imageUrl
         super.init(frame: .zero)
         
         self.addSubviews(
@@ -133,6 +129,8 @@ class LogTicketView: UIView {
         )
         setLayouts()
         setButtonTarget()
+        setCollectionView()
+        setPageControl()
         
         self.addSubview(blurEffectView)
         self.sendSubviewToBack(blurEffectView)
@@ -182,11 +180,12 @@ extension LogTicketView: UIScrollViewDelegate {
     private func setCollectionView() {
         switch imageUrl.isEmpty {
         case true:
+            emptyImageView.backgroundColor = .red
             addSubview(emptyImageView)
             imageCollectionView.isHidden = true
 
             emptyImageView.snp.makeConstraints { make in
-                make.width.equalToSuperview()
+                make.width.equalToSuperview().multipliedBy(0.6)
                 make.height.equalTo(DeviceInfo.screenHeight * 0.3471563981)
                 make.centerX.equalToSuperview()
                 make.top.equalToSuperview()

--- a/Sources/Presenter/Log/LogTicket/View/LogTicketView.swift
+++ b/Sources/Presenter/Log/LogTicket/View/LogTicketView.swift
@@ -180,7 +180,6 @@ extension LogTicketView: UIScrollViewDelegate {
     private func setCollectionView() {
         switch imageUrl.isEmpty {
         case true:
-            emptyImageView.backgroundColor = .red
             addSubview(emptyImageView)
             imageCollectionView.isHidden = true
 

--- a/Sources/Presenter/Log/LogTicket/ViewController/LogTicketViewController.swift
+++ b/Sources/Presenter/Log/LogTicket/ViewController/LogTicketViewController.swift
@@ -151,7 +151,7 @@ extension LogTicketViewController {
     private func setOnlyMyReview() {
         
         let myTicketView = LogTicketView(viewModel: viewModel, imageUrl: viewModel.reviews[0].imagesURL)
-        let logTicketEmptyView = LogTicketEmptyView()
+        let logTicketEmptyView = LogTicketEmptyView(viewModel: viewModel)
         
         myTicketView.rootViewState = rootViewState
         logTicketEmptyView.rootViewState = rootViewState
@@ -185,7 +185,7 @@ extension LogTicketViewController {
     
     private func setOnlyMateReview() {
         
-        let logTicketEmptyView = LogTicketEmptyView()
+        let logTicketEmptyView = LogTicketEmptyView(viewModel: viewModel)
         let mateTicketView = LogTicketView(viewModel: viewModel, imageUrl: viewModel.reviews[1].imagesURL)
         
         logTicketEmptyView.rootViewState = rootViewState

--- a/Sources/Presenter/Log/LogTicket/ViewController/LogTicketViewController.swift
+++ b/Sources/Presenter/Log/LogTicket/ViewController/LogTicketViewController.swift
@@ -150,7 +150,7 @@ extension LogTicketViewController {
     
     private func setOnlyMyReview() {
         
-        let myTicketView = LogTicketView(viewModel: viewModel)
+        let myTicketView = LogTicketView(viewModel: viewModel, imageUrl: viewModel.reviews[0].imagesURL)
         let logTicketEmptyView = LogTicketEmptyView()
         
         myTicketView.rootViewState = rootViewState
@@ -186,7 +186,7 @@ extension LogTicketViewController {
     private func setOnlyMateReview() {
         
         let logTicketEmptyView = LogTicketEmptyView()
-        let mateTicketView = LogTicketView(viewModel: viewModel)
+        let mateTicketView = LogTicketView(viewModel: viewModel, imageUrl: viewModel.reviews[1].imagesURL)
         
         logTicketEmptyView.rootViewState = rootViewState
         mateTicketView.rootViewState = rootViewState
@@ -219,8 +219,8 @@ extension LogTicketViewController {
     
     private func setBothReview() {
         
-        let myTicketView = LogTicketView(viewModel: viewModel)
-        let mateTicketView = LogTicketView(viewModel: viewModel)
+        let myTicketView = LogTicketView(viewModel: viewModel, imageUrl: viewModel.reviews[0].imagesURL)
+        let mateTicketView = LogTicketView(viewModel: viewModel, imageUrl: viewModel.reviews[1].imagesURL)
         
         myTicketView.rootViewState = rootViewState
         mateTicketView.rootViewState = rootViewState


### PR DESCRIPTION
## 🔍 개요

LogTicketView에서 DismissButton이 제대로 작동하지 않는 버그를 수정했습니다.
원인은 이미지가 버튼 영역을 침법했기 때문이었고, 레이아웃을 수정했습니다.


## 📝 작업사항
- [x] dismissButton layout 조정
- [x] 리뷰가 없을 시, dismissButton이 없었음 -> 추가 완료

## 📸 스크린샷 또는 영상

| 메이트의 리뷰 | 내 리뷰 - 사진 없을 시 | 리뷰가 없을 시 |
|-----|-----|-----|
| <img src="https://user-images.githubusercontent.com/81943525/206688973-be529ac4-e75d-4018-97b4-8af1124c7386.png" width="250"> | <img src="https://user-images.githubusercontent.com/81943525/206689189-9c79cf2d-06a9-4f49-9fb8-2eb2a0185092.png" width="250"> | <img src="https://user-images.githubusercontent.com/81943525/206689147-5a3bf7ab-0401-46fa-acdc-a9c57ffbd8a2.png" width="250">   |

> 셋 다 작동 됨을 확인했습니다.